### PR TITLE
Fix broken README images, consolidate a11y section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/Pro777/alcove/main/docs/assets/logo.svg" alt="Alcove" height="56">
+# Alcove
 
 <p>
   <a href="https://github.com/Pro777/alcove/actions/workflows/ci.yml"><img src="https://github.com/Pro777/alcove/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
@@ -44,8 +44,6 @@ alcove seed-demo          # download sample corpus + build index
 alcove serve              # open http://localhost:8000
 ```
 
-<img src="https://raw.githubusercontent.com/Pro777/alcove/main/docs/assets/web-ui-screenshot.png" alt="Alcove web UI" width="760">
-
 ## 🔒 Trust Model
 
 - Local disk only — no hosted control plane
@@ -60,10 +58,7 @@ alcove serve              # open http://localhost:8000
 - [Security](docs/SECURITY.md)
 - [Seed Corpus](docs/SEED_CORPUS.md)
 - [Roadmap](docs/ROADMAP.md)
-
-## Accessibility
-
-Alcove targets WCAG AA compliance. See [ACCESSIBILITY.md](ACCESSIBILITY.md) for details.
+- [Accessibility](ACCESSIBILITY.md) — WCAG AA compliance target
 
 ## 📄 License
 


### PR DESCRIPTION
## Closed — wrong approach

Removing images was wrong. The assets should be published from the private repo via GitHub Actions. See replacement issue.