### PR TITLE
Fix broken README images with relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://raw.githubusercontent.com/Pro777/alcove/main/docs/assets/logo.svg" alt="Alcove" height="56">
+<img src="docs/assets/logo.svg" alt="Alcove" height="56">
 
 <p>
   <a href="https://github.com/Pro777/alcove/actions/workflows/ci.yml"><img src="https://github.com/Pro777/alcove/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
@@ -44,7 +44,7 @@ alcove seed-demo          # download sample corpus + build index
 alcove serve              # open http://localhost:8000
 ```
 
-<img src="https://raw.githubusercontent.com/Pro777/alcove/main/docs/assets/web-ui-screenshot.png" alt="Alcove web UI" width="760">
+<img src="docs/assets/web-ui-screenshot.png" alt="Alcove web UI" width="760">
 
 ## 🔒 Trust Model
 
@@ -60,10 +60,7 @@ alcove serve              # open http://localhost:8000
 - [Security](docs/SECURITY.md)
 - [Seed Corpus](docs/SEED_CORPUS.md)
 - [Roadmap](docs/ROADMAP.md)
-
-## Accessibility
-
-Alcove targets WCAG AA compliance. See [ACCESSIBILITY.md](ACCESSIBILITY.md) for details.
+- [Accessibility](ACCESSIBILITY.md) — WCAG AA compliance target
 
 ## 📄 License
 


### PR DESCRIPTION
## Summary
- Switch logo and screenshot from absolute `raw.githubusercontent.com` URLs to relative paths (`docs/assets/logo.svg`, `docs/assets/web-ui-screenshot.png`)
- Absolute URLs 404 because the repo is private — GitHub can't resolve them without auth. Relative paths render with authentication context.
- Move standalone Accessibility section into a bullet under Documentation

## Root cause
`raw.githubusercontent.com` returns 404 for private repos. The images are committed and present — just unreachable via absolute URL.

## Test plan
- [ ] Verify both images render on the PR branch README
- [ ] Confirm accessibility link works in docs list