### PR TITLE
Remove network-dependent seed fetch from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,6 @@ jobs:
           cp .env.example .env
           mkdir -p data/raw data/processed data/chroma
 
-      - name: Run seed demo
-        run: make seed-demo
-
       - name: Run tests
         run: python -m pytest -q
 


### PR DESCRIPTION
CI was failing because `make seed-demo` fetches external URLs (Gutenberg, archives.gov) that are unreachable from GitHub Actions runners. The seed smoke test already skips gracefully when seed data is absent, so the fetch step is unnecessary in CI.

Removes the `Run seed demo` step from ci.yml. Tests still run normally.