### PR TITLE
Add landing page link to README and project URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Alcove is local-first search for your documents. Point it at a directory. It chu
 
 PDF, EPUB, HTML, Markdown, CSV, JSON, JSONL, DOCX, RST, TSV, and plain text all work out of the box. The same pipeline indexes a personal research library, a community archive, or a municipal records collection.
 
-**[Watch the 30-second demo](https://pro777.github.io/alcove/demo.html)**
+**[Landing page](https://pro777.github.io/alcove/)** · **[30-second demo](https://pro777.github.io/alcove/demo.html)**
 
 ## Quick start
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,10 @@ semantic = ["sentence-transformers>=3.0"]
 epub = ["ebooklib>=0.18,<1.0"]
 zvec = ["zvec>=0.1"]
 
+[project.urls]
+Homepage = "https://pro777.github.io/alcove/"
+Repository = "https://github.com/Pro777/alcove"
+
 [project.scripts]
 alcove = "alcove.cli:main"
 


### PR DESCRIPTION
## Summary
- Added a link to the landing page (`https://pro777.github.io/alcove/`) in README.md alongside the existing demo link.
- Added a `[project.urls]` section in `pyproject.toml` with `Homepage` and `Repository` entries.

## Test plan
- [ ] Verify the landing page link renders correctly in the README on GitHub
- [ ] Verify PyPI metadata picks up the new URLs on next publish