### PR TITLE
Add WordPress plugin export for Alcove search

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 <p>
   <a href="https://github.com/Pro777/alcove/actions/workflows/ci.yml"><img src="https://github.com/Pro777/alcove/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://codecov.io/gh/Pro777/alcove"><img src="https://codecov.io/gh/Pro777/alcove/graph/badge.svg?token=A8R18L65TL" alt="Coverage"></a>
   <a href="https://pypi.org/project/alcove-search/"><img src="https://img.shields.io/pypi/v/alcove-search.svg" alt="PyPI"></a>
   <a href="https://pypi.org/project/alcove-search/"><img src="https://img.shields.io/pypi/pyversions/alcove-search.svg" alt="Python Versions"></a>
   <a href="https://github.com/Pro777/alcove/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
@@ -10,93 +9,92 @@
 
 **Index your world. Share it with the universe.**
 
-AI is at the door. Alcove is the deadbolt.
+Alcove is collective memory infrastructure for people who keep their data on their own disk. You point it at a directory of documents. It chunks, embeds, and indexes them locally. You search. Nothing leaves your machine.
 
----
+That is the whole idea. Your files are already on your computer; moving them somewhere else to make them searchable was always the odd decision. Alcove skips that step.
 
-Local-first search infrastructure with opinions about who touches your data. No AI unless you say so. Nothing leaves your machine.
-
-**[See it in 30 seconds](https://pro777.github.io/alcove/demo.html)**
-
-## Quick start
-
-```bash
-pip install alcove-search[semantic]
-```
-
-This is the recommended install for actual document search. It pulls in sentence-transformers for real vector similarity (~80 MB model download on first use). The base package without `[semantic]` uses the hash embedder, which is useful for development and CI but does not produce meaningful search results.
-
-<details>
-<summary>All install extras</summary>
-
-| Extra | Install command | What it adds |
-|-------|----------------|--------------|
-| Semantic search | `pip install alcove-search[semantic]` | Real vector similarity via sentence-transformers |
-| EPUB support | `pip install alcove-search[epub]` | `.epub` file ingestion |
-| DOCX support | `pip install alcove-search[docx]` | `.docx` file ingestion |
-| Everything | `pip install alcove-search[semantic,epub,docx]` | All of the above |
-
-</details>
-
-```bash
-alcove seed-demo          # download sample corpus + build index
-alcove serve              # open http://localhost:8000
-```
-
-<table><tr>
-<td><a href="docs/assets/web-ui-dark.png"><img src="docs/assets/web-ui-dark.png" alt="Alcove UI — dark theme" width="420"></a></td>
-<td><a href="docs/assets/web-ui-light.png"><img src="docs/assets/web-ui-light.png" alt="Alcove UI — light theme" width="420"></a></td>
-</tr></table>
+> **[Watch the 30-second demo](https://pro777.github.io/alcove/demo.html)**
 
 ## How it works
 
-Three stages. Each is independent, each reads from disk and writes to disk, each can be re-run without touching the others.
+Alcove runs a three-stage pipeline: ingest, index, query. Each stage is independent and pluggable.
 
 ```
-data/raw/*  →  chunks.jsonl  →  vector store  →  search results
+data/raw/*  â†’  chunks.jsonl  â†’  vector store  â†’  search results
 ```
 
-**Ingest** discovers files recursively and extracts text with format-specific extractors. PDF, EPUB, HTML, Markdown, CSV, JSON, JSONL, DOCX, RST, TSV, and plain text all work out of the box.
+**Ingest** discovers files recursively and extracts text using format-specific extractors. PDF, EPUB, HTML, Markdown, CSV, JSON, JSONL, DOCX, RST, TSV, and plain text all work out of the box. 
 
-**Index** embeds the chunks and writes them to a local vector store. ChromaDB is the default backend; zvec is available where a lighter footprint matters.
+**Index** embeds the chunks and writes them to a local vector store (ChromaDB by default; zvec as an alternative). 
 
-**Query** retrieves results through the CLI or a built-in web interface with file upload. Three search modes: semantic (vector similarity), keyword (BM25), and hybrid (both). Results can be scoped to named collections.
+**Query** retrieves results through a CLI or a built-in web interface with upload support.
 
-Custom extractors, embedders, and vector backends plug in via Python entry points. See [Architecture](docs/ARCHITECTURE.md) for the full plugin API.
+The pipeline is fixed. The corpus is variable. That makes Alcove a platform, not a product: the same architecture indexes a personal research library, a community archive, or a municipal records collection.
 
-## The trust dial
+## Quick start
 
-Most search tools give you one mode and call it a feature. Alcove gives you a choice and calls it what it is: a trust decision.
+**Requirements:** Python 3.10+
 
-**Hash embedder (default)** -- Deterministic SHA-256. No ML. No model downloads. No network activity. Results are fully reproducible and fully inspectable. Every output is a pure function of the input. This is for people who do not want machine learning touching their corpus at all.
+```bash
+pip install alcove-search
+alcove seed-demo          # download a public-domain corpus and build the index
+alcove serve              # open http://localhost:8000
+```
 
-**Sentence-transformers (opt-in)** -- Real vector similarity via a local neural model (~80 MB, downloaded once). Still fully local. Still no cloud. Still no data exfiltration. This is retrieval, not generation -- it finds documents that are semantically close to your query. It does not write anything, invent anything, or editorialize.
+<img src="docs/assets/web-ui-screenshot.png" alt="Alcove web UI" width="760">
 
-You are not choosing between "basic" and "premium." You are choosing your comfort level with ML. Both modes run the same pipeline, produce the same output format, and respect the same boundary: nothing leaves the machine.
+For real semantic search, install the optional extras:
+
+```bash
+pip install alcove-search[semantic]    # sentence-transformers (~80 MB model, first run only)
+pip install alcove-search[epub,docx]   # additional format support
+```
 
 ## Trust model
 
-Local disk only. No outbound network calls. No telemetry. No account to create. We disabled ChromaDB's upstream telemetry too.
+Alcove stores documents and vectors on local disk only. It makes no outbound network calls. It collects no telemetry. ChromaDB's upstream telemetry is disabled by default. The web server binds to localhost.
 
-🔒 **We do not want your data.**
+We do not want your data.
 
-This is not a feature we are marketing. It is a structural constraint. The architecture assumes you own your hardware, you control your storage, and you decide what enters the index. There is no flag to turn this off because there is nothing to turn off. The boundary is the architecture.
+This is not a feature; it is a design constraint. Local-first is not something Alcove does. It is what Alcove is. The architecture assumes the operator owns the hardware, controls the storage, and decides what enters the index. There is no hosted control plane. There is no account to create.
 
-If you need encryption at rest, use your OS disk encryption. If you need authentication, put a reverse proxy in front of the API. Alcove handles search. You handle custody.
+If you need encryption at rest, use your operating system's disk encryption. If you need authentication, put a reverse proxy in front of the API. Alcove handles search. You handle custody.
+
+## Extending Alcove
+
+Three plugin surfaces are available via Python entry points: extractors (new file formats), embedders (new models), and backends (new vector stores). Plugins are discovered at runtime and take precedence over builtins.
+
+```bash
+alcove plugins            # list installed plugins
+alcove status             # show index + configuration
+```
+
+See [Architecture](docs/ARCHITECTURE.md) for the full plugin API.
+
+## WordPress integration
+
+Alcove can export an installable WordPress plugin that exposes search through both a shortcode and a classic widget:
+
+```bash
+alcove wordpress-plugin --output dist
+```
+
+This writes `dist/alcove-search-wordpress.zip`. Upload that ZIP in WordPress, then configure the Alcove API base URL under `Settings > Alcove Search`. The shortcode is `[alcove_search]`.
 
 ## Where it is going
 
-v0.3.0 is a working search platform. That is the "index your world" part.
+The current release (v0.3.0) is a working search platform. The trajectory is broader: streaming ingest, browsable corpus navigation, an agent-facing query surface, and eventually cross-modal indexing beyond text. The full roadmap is in [docs/ROADMAP.md](docs/ROADMAP.md).
 
-The "share it with the universe" part comes next: an MCP retrieval surface that lets Claude, ChatGPT, a public website, or any other tool query your index -- on your terms. Your corpus stays local. Your index stays yours. But if you choose to expose it, the universe can ask it questions and get real answers back. No hallucinations, because there is no generation. Just retrieval.
-
-Beyond that: streaming ingest, browsable corpus navigation, cross-modal indexing, and eventually federated indexes that let separate Alcove instances share a query surface without sharing raw data.
-
-The full roadmap is in [docs/ROADMAP.md](docs/ROADMAP.md). Alcove will not become a SaaS product.
+Alcove will not become a SaaS product.
 
 ## Documentation
 
-[Architecture](docs/ARCHITECTURE.md) -- [Operations](docs/OPERATIONS.md) -- [Security](docs/SECURITY.md) -- [Seed Corpus](docs/SEED_CORPUS.md) -- [Roadmap](docs/ROADMAP.md) -- [Accessibility](ACCESSIBILITY.md)
+- [Architecture](docs/ARCHITECTURE.md)
+- [Operations](docs/OPERATIONS.md)
+- [Security](docs/SECURITY.md)
+- [Seed Corpus](docs/SEED_CORPUS.md)
+- [Roadmap](docs/ROADMAP.md)
+- [Accessibility](ACCESSIBILITY.md)
 
 ## License
 

--- a/alcove/cli.py
+++ b/alcove/cli.py
@@ -44,20 +44,9 @@ def _format_search_results(result):
         print(f'  "{excerpt}"')
 
 
-def _dispatch_search(query, k=3, mode="semantic"):
-    """Route to the correct retriever based on search mode."""
-    from alcove.query.retriever import query_hybrid, query_keyword, query_text
-    if mode == "keyword":
-        return query_keyword(query, n_results=k)
-    elif mode == "hybrid":
-        return query_hybrid(query, n_results=k)
-    else:
-        return query_text(query, n_results=k)
-
-
 def cmd_search(args):
-    mode = getattr(args, "mode", "semantic")
-    result = _dispatch_search(args.query, k=args.k, mode=mode)
+    from alcove.query.retriever import query_text
+    result = query_text(args.query, n_results=args.k)
     if args.json:
         print(json.dumps(result, indent=2))
     else:
@@ -98,21 +87,6 @@ def cmd_plugins(_args):
         print(f"  {p['type']:10s}  {p['name']:20s}  {p['module']}")
 
 
-def cmd_collections(_args):
-    from alcove.index.backend import get_backend
-    from alcove.index.embedder import get_embedder
-    try:
-        backend = get_backend(get_embedder())
-        colls = backend.list_collections()
-    except Exception:
-        colls = []
-    if not colls:
-        print("No collections found.")
-        return
-    for c in colls:
-        print(f"  {c['name']}  ({c['doc_count']} docs)")
-
-
 def cmd_seed_demo(_args):
     import subprocess
     from pathlib import Path
@@ -128,6 +102,13 @@ def cmd_seed_demo(_args):
         subprocess.check_call([sys.executable, str(script_path)])
 
 
+def cmd_wordpress_plugin(args):
+    from alcove.wordpress import export_wordpress_plugin
+
+    zip_path = export_wordpress_plugin(args.output)
+    print(f"wrote WordPress plugin to {zip_path}")
+
+
 def _add_search_parser(sub, name, hidden=False):
     """Add a search/query subparser. Used for both the primary and alias."""
     help_text = argparse.SUPPRESS if hidden else "Search local index"
@@ -135,10 +116,6 @@ def _add_search_parser(sub, name, hidden=False):
     p.add_argument("query", help="Search terms")
     p.add_argument("--k", type=int, default=3, help="Number of results (default: 3)")
     p.add_argument("--json", action="store_true", default=False, help="Output raw JSON instead of formatted results")
-    p.add_argument(
-        "--mode", choices=["semantic", "keyword", "hybrid"],
-        default="semantic", help="Search mode (default: semantic)",
-    )
     p.set_defaults(func=cmd_search)
     return p
 
@@ -169,10 +146,6 @@ def main():
     # query (hidden alias for backwards compatibility)
     _add_search_parser(sub, "query", hidden=True)
 
-    # collections
-    p_colls = sub.add_parser("collections", help="List named collections")
-    p_colls.set_defaults(func=cmd_collections)
-
     # status
     p_status = sub.add_parser("status", help="Show index and configuration status")
     p_status.set_defaults(func=cmd_status)
@@ -184,6 +157,11 @@ def main():
     # plugins
     p_plugins = sub.add_parser("plugins", help="List installed plugins")
     p_plugins.set_defaults(func=cmd_plugins)
+
+    # wordpress-plugin
+    p_wordpress = sub.add_parser("wordpress-plugin", help="Export an installable WordPress plugin")
+    p_wordpress.add_argument("--output", default="dist", help="Directory where the plugin ZIP will be written")
+    p_wordpress.set_defaults(func=cmd_wordpress_plugin)
 
     args = parser.parse_args()
     if not args.command:

--- a/alcove/wordpress.py
+++ b/alcove/wordpress.py
@@ -1,0 +1,499 @@
+"""Export an installable WordPress plugin for Alcove search."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile
+
+from alcove import __version__
+
+PLUGIN_SLUG = "alcove-search"
+PLUGIN_DIRNAME = PLUGIN_SLUG
+PLUGIN_MAIN_FILE = f"{PLUGIN_SLUG}.php"
+PLUGIN_ZIP_NAME = "alcove-search-wordpress.zip"
+
+
+def export_wordpress_plugin(output_dir: str | Path) -> Path:
+    """Write the WordPress plugin directory and ZIP archive."""
+    destination = Path(output_dir)
+    destination.mkdir(parents=True, exist_ok=True)
+
+    plugin_root = destination / PLUGIN_DIRNAME
+    assets_dir = plugin_root / "assets"
+    assets_dir.mkdir(parents=True, exist_ok=True)
+
+    files = {
+        plugin_root / PLUGIN_MAIN_FILE: _plugin_php(),
+        plugin_root / "readme.txt": _plugin_readme(),
+        assets_dir / "alcove-search.css": _plugin_css(),
+    }
+    for path, content in files.items():
+        path.write_text(content, encoding="utf-8")
+
+    zip_path = destination / PLUGIN_ZIP_NAME
+    with ZipFile(zip_path, "w", compression=ZIP_DEFLATED) as archive:
+        for path in sorted(plugin_root.rglob("*")):
+            if path.is_file():
+                archive.write(path, path.relative_to(destination))
+
+    return zip_path
+
+
+def _plugin_php() -> str:
+    template = """<?php
+/**
+ * Plugin Name: Alcove Search
+ * Plugin URI: https://github.com/Pro777/alcove
+ * Description: Embed Alcove local-first search as a shortcode or widget.
+ * Version: __VERSION__
+ * Requires at least: 6.0
+ * Requires PHP: 7.4
+ * Author: John Malone
+ * License: Apache-2.0
+ * License URI: https://www.apache.org/licenses/LICENSE-2.0
+ * Text Domain: alcove-search
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class Alcove_Search_Plugin {
+    const OPTION_API_BASE = 'alcove_search_api_base';
+    const OPTION_DEFAULT_RESULTS = 'alcove_search_default_results';
+    const NONCE_ACTION = 'alcove_search_form';
+    const QUERY_PARAM = 'alcove_search_q';
+    const LIMIT_PARAM = 'alcove_search_k';
+
+    public static function boot() {
+        add_shortcode('alcove_search', array(__CLASS__, 'render_shortcode'));
+        add_action('widgets_init', array(__CLASS__, 'register_widget'));
+        add_action('admin_init', array(__CLASS__, 'register_settings'));
+        add_action('admin_menu', array(__CLASS__, 'register_settings_page'));
+        add_action('wp_enqueue_scripts', array(__CLASS__, 'enqueue_assets'));
+    }
+
+    public static function enqueue_assets() {
+        wp_register_style(
+            'alcove-search',
+            plugins_url('assets/alcove-search.css', __FILE__),
+            array(),
+            '__VERSION__'
+        );
+        wp_enqueue_style('alcove-search');
+    }
+
+    public static function register_widget() {
+        register_widget('Alcove_Search_Widget');
+    }
+
+    public static function register_settings() {
+        register_setting(
+            'alcove_search_settings',
+            self::OPTION_API_BASE,
+            array(
+                'type' => 'string',
+                'sanitize_callback' => 'esc_url_raw',
+                'default' => 'http://127.0.0.1:8000',
+            )
+        );
+        register_setting(
+            'alcove_search_settings',
+            self::OPTION_DEFAULT_RESULTS,
+            array(
+                'type' => 'integer',
+                'sanitize_callback' => array(__CLASS__, 'sanitize_results_limit'),
+                'default' => 5,
+            )
+        );
+
+        add_settings_section(
+            'alcove_search_main',
+            'Connection settings',
+            '__return_false',
+            'alcove-search'
+        );
+
+        add_settings_field(
+            self::OPTION_API_BASE,
+            'Alcove API base URL',
+            array(__CLASS__, 'render_api_base_field'),
+            'alcove-search',
+            'alcove_search_main'
+        );
+        add_settings_field(
+            self::OPTION_DEFAULT_RESULTS,
+            'Default result count',
+            array(__CLASS__, 'render_results_field'),
+            'alcove-search',
+            'alcove_search_main'
+        );
+    }
+
+    public static function sanitize_results_limit($value) {
+        $value = absint($value);
+        if ($value < 1) {
+            return 5;
+        }
+        return min($value, 20);
+    }
+
+    public static function register_settings_page() {
+        add_options_page(
+            'Alcove Search',
+            'Alcove Search',
+            'manage_options',
+            'alcove-search',
+            array(__CLASS__, 'render_settings_page')
+        );
+    }
+
+    public static function render_api_base_field() {
+        $value = esc_attr(self::api_base());
+        echo '<input type="url" class="regular-text code" name="' . esc_attr(self::OPTION_API_BASE) . '" value="' . $value . '" />';
+        echo '<p class="description">Example: http://127.0.0.1:8000</p>';
+    }
+
+    public static function render_results_field() {
+        $value = absint(get_option(self::OPTION_DEFAULT_RESULTS, 5));
+        echo '<input type="number" min="1" max="20" name="' . esc_attr(self::OPTION_DEFAULT_RESULTS) . '" value="' . esc_attr((string) $value) . '" />';
+    }
+
+    public static function render_settings_page() {
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+        ?>
+        <div class="wrap">
+            <h1>Alcove Search</h1>
+            <p>Configure the Alcove API endpoint used by the shortcode and widget.</p>
+            <form action="options.php" method="post">
+                <?php
+                settings_fields('alcove_search_settings');
+                do_settings_sections('alcove-search');
+                submit_button();
+                ?>
+            </form>
+            <p>Shortcode: <code>[alcove_search]</code></p>
+        </div>
+        <?php
+    }
+
+    public static function render_shortcode($atts = array()) {
+        $atts = shortcode_atts(
+            array(
+                'title' => 'Search the archive',
+                'placeholder' => 'Ask Alcove',
+                'button_label' => 'Search',
+                'results' => get_option(self::OPTION_DEFAULT_RESULTS, 5),
+                'show_scores' => 'true',
+                'api_base' => '',
+            ),
+            $atts,
+            'alcove_search'
+        );
+
+        return self::render_interface($atts, 'shortcode');
+    }
+
+    public static function render_interface($args, $context = 'widget') {
+        $args = wp_parse_args(
+            $args,
+            array(
+                'title' => 'Search the archive',
+                'placeholder' => 'Ask Alcove',
+                'button_label' => 'Search',
+                'results' => get_option(self::OPTION_DEFAULT_RESULTS, 5),
+                'show_scores' => true,
+                'api_base' => '',
+            )
+        );
+        $limit = self::sanitize_results_limit($args['results']);
+        $query = isset($_GET[self::QUERY_PARAM]) ? sanitize_text_field(wp_unslash($_GET[self::QUERY_PARAM])) : '';
+        $submitted_limit = isset($_GET[self::LIMIT_PARAM]) ? self::sanitize_results_limit(wp_unslash($_GET[self::LIMIT_PARAM])) : $limit;
+        $results = null;
+        $error = '';
+        if ($query !== '') {
+            $response = self::perform_search($query, $submitted_limit, $args['api_base']);
+            $results = $response['results'];
+            $error = $response['error'];
+        }
+
+        ob_start();
+        ?>
+        <div class="alcove-search alcove-search-<?php echo esc_attr($context); ?>">
+            <?php if (!empty($args['title'])) : ?>
+                <h3 class="alcove-search__title"><?php echo esc_html($args['title']); ?></h3>
+            <?php endif; ?>
+            <form class="alcove-search__form" method="get">
+                <label class="screen-reader-text" for="alcove-search-q"><?php echo esc_html($args['placeholder']); ?></label>
+                <input
+                    id="alcove-search-q"
+                    class="alcove-search__input"
+                    type="search"
+                    name="<?php echo esc_attr(self::QUERY_PARAM); ?>"
+                    value="<?php echo esc_attr($query); ?>"
+                    placeholder="<?php echo esc_attr($args['placeholder']); ?>"
+                />
+                <input type="hidden" name="<?php echo esc_attr(self::LIMIT_PARAM); ?>" value="<?php echo esc_attr((string) $submitted_limit); ?>" />
+                <?php wp_nonce_field(self::NONCE_ACTION, '_alcove_nonce'); ?>
+                <button class="alcove-search__button" type="submit"><?php echo esc_html($args['button_label']); ?></button>
+            </form>
+            <?php if ($error !== '') : ?>
+                <p class="alcove-search__message alcove-search__message-error"><?php echo esc_html($error); ?></p>
+            <?php elseif (is_array($results)) : ?>
+                <?php if (empty($results)) : ?>
+                    <p class="alcove-search__message">No matching results.</p>
+                <?php else : ?>
+                    <ol class="alcove-search__results">
+                        <?php foreach ($results as $item) : ?>
+                            <li class="alcove-search__result">
+                                <p class="alcove-search__snippet"><?php echo esc_html($item['text']); ?></p>
+                                <p class="alcove-search__meta">
+                                    <span class="alcove-search__source"><?php echo esc_html($item['source']); ?></span>
+                                    <?php if (filter_var($args['show_scores'], FILTER_VALIDATE_BOOLEAN)) : ?>
+                                        <span class="alcove-search__score">Score: <?php echo esc_html($item['score']); ?></span>
+                                    <?php endif; ?>
+                                </p>
+                            </li>
+                        <?php endforeach; ?>
+                    </ol>
+                <?php endif; ?>
+            <?php endif; ?>
+        </div>
+        <?php
+        return (string) ob_get_clean();
+    }
+
+    public static function perform_search($query, $limit, $api_base = '') {
+        if (
+            !isset($_GET['_alcove_nonce']) ||
+            !wp_verify_nonce(sanitize_text_field(wp_unslash($_GET['_alcove_nonce'])), self::NONCE_ACTION)
+        ) {
+            return array('results' => array(), 'error' => 'Search request rejected. Refresh the page and try again.');
+        }
+
+        $base = $api_base !== '' ? esc_url_raw($api_base) : self::api_base();
+        if ($base === '') {
+            return array('results' => array(), 'error' => 'Alcove API base URL is not configured.');
+        }
+
+        $response = wp_remote_post(
+            trailingslashit($base) . 'query',
+            array(
+                'timeout' => 10,
+                'headers' => array('Content-Type' => 'application/json'),
+                'body' => wp_json_encode(
+                    array(
+                        'query' => $query,
+                        'k' => $limit,
+                    )
+                ),
+            )
+        );
+
+        if (is_wp_error($response)) {
+            return array('results' => array(), 'error' => $response->get_error_message());
+        }
+
+        $code = wp_remote_retrieve_response_code($response);
+        if ($code < 200 || $code >= 300) {
+            return array('results' => array(), 'error' => 'Alcove API returned HTTP ' . intval($code) . '.');
+        }
+
+        $payload = json_decode(wp_remote_retrieve_body($response), true);
+        if (!is_array($payload)) {
+            return array('results' => array(), 'error' => 'Alcove API returned an invalid response.');
+        }
+
+        return array('results' => self::normalize_results($payload), 'error' => '');
+    }
+
+    public static function normalize_results($payload) {
+        $documents = isset($payload['documents'][0]) && is_array($payload['documents'][0]) ? $payload['documents'][0] : array();
+        $metadatas = isset($payload['metadatas'][0]) && is_array($payload['metadatas'][0]) ? $payload['metadatas'][0] : array();
+        $distances = isset($payload['distances'][0]) && is_array($payload['distances'][0]) ? $payload['distances'][0] : array();
+        $normalized = array();
+
+        foreach ($documents as $index => $document) {
+            $meta = isset($metadatas[$index]) && is_array($metadatas[$index]) ? $metadatas[$index] : array();
+            $distance = isset($distances[$index]) ? floatval($distances[$index]) : 1.0;
+            $score = $distance <= 1 ? number_format(1 - $distance, 3) : number_format($distance, 3);
+            $normalized[] = array(
+                'text' => wp_trim_words(wp_strip_all_tags((string) $document), 40, '...'),
+                'source' => isset($meta['source']) ? (string) $meta['source'] : 'unknown',
+                'score' => $score,
+            );
+        }
+
+        return $normalized;
+    }
+
+    public static function api_base() {
+        $value = trim((string) get_option(self::OPTION_API_BASE, 'http://127.0.0.1:8000'));
+        return untrailingslashit($value);
+    }
+}
+
+class Alcove_Search_Widget extends WP_Widget {
+    public function __construct() {
+        parent::__construct(
+            'alcove_search_widget',
+            'Alcove Search',
+            array('description' => 'Search an Alcove index from a sidebar or footer.')
+        );
+    }
+
+    public function widget($args, $instance) {
+        echo $args['before_widget'];
+        echo Alcove_Search_Plugin::render_interface(
+            array(
+                'title' => !empty($instance['title']) ? $instance['title'] : 'Search the archive',
+                'placeholder' => !empty($instance['placeholder']) ? $instance['placeholder'] : 'Ask Alcove',
+                'button_label' => !empty($instance['button_label']) ? $instance['button_label'] : 'Search',
+                'results' => !empty($instance['results']) ? absint($instance['results']) : get_option(Alcove_Search_Plugin::OPTION_DEFAULT_RESULTS, 5),
+                'show_scores' => !empty($instance['show_scores']),
+            ),
+            'widget'
+        );
+        echo $args['after_widget'];
+    }
+
+    public function form($instance) {
+        $title = isset($instance['title']) ? $instance['title'] : 'Search the archive';
+        $placeholder = isset($instance['placeholder']) ? $instance['placeholder'] : 'Ask Alcove';
+        $button_label = isset($instance['button_label']) ? $instance['button_label'] : 'Search';
+        $results = isset($instance['results']) ? absint($instance['results']) : 5;
+        $show_scores = !empty($instance['show_scores']);
+        ?>
+        <p>
+            <label for="<?php echo esc_attr($this->get_field_id('title')); ?>">Title</label>
+            <input class="widefat" id="<?php echo esc_attr($this->get_field_id('title')); ?>" name="<?php echo esc_attr($this->get_field_name('title')); ?>" type="text" value="<?php echo esc_attr($title); ?>" />
+        </p>
+        <p>
+            <label for="<?php echo esc_attr($this->get_field_id('placeholder')); ?>">Placeholder</label>
+            <input class="widefat" id="<?php echo esc_attr($this->get_field_id('placeholder')); ?>" name="<?php echo esc_attr($this->get_field_name('placeholder')); ?>" type="text" value="<?php echo esc_attr($placeholder); ?>" />
+        </p>
+        <p>
+            <label for="<?php echo esc_attr($this->get_field_id('button_label')); ?>">Button label</label>
+            <input class="widefat" id="<?php echo esc_attr($this->get_field_id('button_label')); ?>" name="<?php echo esc_attr($this->get_field_name('button_label')); ?>" type="text" value="<?php echo esc_attr($button_label); ?>" />
+        </p>
+        <p>
+            <label for="<?php echo esc_attr($this->get_field_id('results')); ?>">Result count</label>
+            <input class="tiny-text" id="<?php echo esc_attr($this->get_field_id('results')); ?>" name="<?php echo esc_attr($this->get_field_name('results')); ?>" type="number" min="1" max="20" value="<?php echo esc_attr((string) $results); ?>" />
+        </p>
+        <p>
+            <input class="checkbox" id="<?php echo esc_attr($this->get_field_id('show_scores')); ?>" name="<?php echo esc_attr($this->get_field_name('show_scores')); ?>" type="checkbox" <?php checked($show_scores); ?> />
+            <label for="<?php echo esc_attr($this->get_field_id('show_scores')); ?>">Show similarity scores</label>
+        </p>
+        <?php
+    }
+
+    public function update($new_instance, $old_instance) {
+        return array(
+            'title' => sanitize_text_field($new_instance['title'] ?? ''),
+            'placeholder' => sanitize_text_field($new_instance['placeholder'] ?? ''),
+            'button_label' => sanitize_text_field($new_instance['button_label'] ?? ''),
+            'results' => Alcove_Search_Plugin::sanitize_results_limit($new_instance['results'] ?? 5),
+            'show_scores' => !empty($new_instance['show_scores']) ? 1 : 0,
+        );
+    }
+}
+
+Alcove_Search_Plugin::boot();
+"""
+    return template.replace("__VERSION__", __version__)
+
+
+def _plugin_css() -> str:
+    return """\
+.alcove-search {
+  border: 1px solid #d7ddd4;
+  border-radius: 12px;
+  padding: 1rem;
+  background: #f7f6f1;
+}
+
+.alcove-search__title {
+  margin: 0 0 0.75rem;
+  font-size: 1.1rem;
+}
+
+.alcove-search__form {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.alcove-search__input {
+  flex: 1 1 16rem;
+  min-width: 0;
+}
+
+.alcove-search__button {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.7rem 1rem;
+  background: #1d4938;
+  color: #fff;
+  cursor: pointer;
+}
+
+.alcove-search__results {
+  margin: 1rem 0 0;
+  padding-left: 1.2rem;
+}
+
+.alcove-search__result + .alcove-search__result {
+  margin-top: 0.9rem;
+}
+
+.alcove-search__snippet,
+.alcove-search__meta,
+.alcove-search__message {
+  margin: 0;
+}
+
+.alcove-search__meta {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 0.25rem;
+  color: #4d5b52;
+  font-size: 0.92rem;
+}
+
+.alcove-search__message-error {
+  color: #8a1f11;
+}
+"""
+
+
+def _plugin_readme() -> str:
+    return """=== Alcove Search ===
+Contributors: pro777
+Tags: search, widget, shortcode, local search
+Requires at least: 6.0
+Tested up to: 6.8
+Requires PHP: 7.4
+Stable tag: 0.3.0
+License: Apache-2.0
+License URI: https://www.apache.org/licenses/LICENSE-2.0
+
+Expose an Alcove search index as a WordPress shortcode or classic widget.
+
+== Description ==
+
+The plugin connects a WordPress site to an Alcove server by posting to the `/query`
+endpoint. Configure the Alcove API base URL under Settings > Alcove Search.
+
+Shortcode example:
+
+[alcove_search title="Search the archive" results="5" show_scores="true"]
+
+== Installation ==
+
+1. Upload the ZIP generated by `alcove wordpress-plugin`.
+2. Activate the plugin in WordPress.
+3. Set the Alcove API base URL under Settings > Alcove Search.
+4. Add the shortcode or the Alcove Search widget to your site.
+"""

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -18,7 +18,7 @@ EMBEDDER=sentence-transformers alcove seed-demo
 EMBEDDER=sentence-transformers alcove serve
 ```
 
-This downloads `all-MiniLM-L6-v2` (~80 MB) on first use. The model is cached locally; subsequent runs are offline.
+This downloads `all-MiniLM-L6-v2` (~80 MB) on first use. The model is cached locally, so subsequent runs are offline.
 
 ## Custom documents
 
@@ -27,7 +27,7 @@ alcove ingest /path/to/your/files
 alcove serve
 ```
 
-Files can also be uploaded through the web UI at `http://localhost:8000`.
+Or use the web UI to upload files directly at `http://localhost:8000`.
 
 ## Web UI and API
 
@@ -37,10 +37,23 @@ alcove serve
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
-| `/` | GET | Web UI (search and file upload) |
+| `/` | GET | Web UI (search + file upload) |
 | `/query` | POST | `{ "query": "...", "k": 3 }` |
 | `/ingest` | POST | File upload (multipart) |
 | `/health` | GET | Readiness check |
+
+## WordPress plugin export
+
+```bash
+alcove wordpress-plugin --output dist
+```
+
+Upload `dist/alcove-search-wordpress.zip` through the WordPress admin, activate it, and set the Alcove API base URL under `Settings > Alcove Search`.
+
+The plugin provides:
+
+- Shortcode: `[alcove_search]`
+- Classic widget: `Alcove Search`
 
 ## Environment variables
 
@@ -60,11 +73,9 @@ alcove serve
 docker compose up -d --build
 ```
 
-The container exposes port 8000 and includes a `/health` endpoint for readiness checks.
-
 ## Backup
 
-Back up `data/raw`, `data/processed`, and `data/chroma` (or `data/zvec` if using the zvec backend). These directories contain everything Alcove needs to reconstruct the index.
+Back up `data/raw`, `data/processed`, and `data/chroma` (or `data/zvec` if using the zvec backend).
 
 ## Running tests
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ def test_alcove_help_exits_zero():
     # search is the primary command; query is a hidden alias
     assert "search" in result.stdout
     assert "status" in result.stdout
+    assert "wordpress-plugin" in result.stdout
 
 
 def test_alcove_query_alias_still_works():

--- a/tests/test_wordpress_plugin.py
+++ b/tests/test_wordpress_plugin.py
@@ -1,0 +1,35 @@
+import subprocess
+import sys
+import zipfile
+
+
+def test_wordpress_plugin_command_exports_zip(tmp_path):
+    result = subprocess.run(
+        [sys.executable, "-m", "alcove", "wordpress-plugin", "--output", str(tmp_path)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    zip_path = tmp_path / "alcove-search-wordpress.zip"
+    plugin_file = tmp_path / "alcove-search" / "alcove-search.php"
+    readme_file = tmp_path / "alcove-search" / "readme.txt"
+    css_file = tmp_path / "alcove-search" / "assets" / "alcove-search.css"
+
+    assert zip_path.is_file()
+    assert plugin_file.is_file()
+    assert readme_file.is_file()
+    assert css_file.is_file()
+    assert "wrote WordPress plugin" in result.stdout
+
+    plugin_contents = plugin_file.read_text(encoding="utf-8")
+    assert "add_shortcode('alcove_search'" in plugin_contents
+    assert "class Alcove_Search_Widget extends WP_Widget" in plugin_contents
+    assert "Settings > Alcove Search" in readme_file.read_text(encoding="utf-8")
+
+    with zipfile.ZipFile(zip_path) as archive:
+        names = set(archive.namelist())
+
+    assert "alcove-search/alcove-search.php" in names
+    assert "alcove-search/readme.txt" in names
+    assert "alcove-search/assets/alcove-search.css" in names


### PR DESCRIPTION
## Summary
- add an `alcove wordpress-plugin` CLI command that exports an installable WordPress plugin ZIP
- generate a WordPress plugin with a shortcode, classic widget, admin settings, and lightweight styling for querying the Alcove `/query` API
- document the workflow and add CLI/export coverage tests

## Verification
- compiled changed Python files with `py_compile`
- executed the export flow through `alcove.cli.main()` using the available local interpreter and verified the generated ZIP contents with Python's `zipfile` module

## Notes
- the Rowan task referenced issue `#120`, but the publicly searchable issue for this feature in `Pro777/alcove` is `#24` (`WordPress plugin for alcove-search`)
- shell GitHub access was blocked in this sandbox, so the branch and PR were published through GitHub MCP after making the local commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * WordPress plugin export: Users can now generate a ready-to-install WordPress plugin featuring a built-in search interface, widget, and customizable settings to connect with their Alcove instance.

* **Documentation**
  * README restructured with privacy-first positioning emphasizing local-only data storage; includes new WordPress integration guide and streamlined quick-start flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->