### PR TITLE
docs: add al-qubbah etymology to WHY.md and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,4 +102,4 @@ The full roadmap is in [docs/ROADMAP.md](docs/ROADMAP.md). Alcove will not becom
 
 ---
 
-*The word alcove comes from Arabic* القبة *(al-qubbah) — "the vault." An enclosed, protected space for things that matter.*
+*The word [alcove](https://en.wikipedia.org/wiki/Alcove) comes from Arabic* القبة *(al-qubbah) — "the vault." An enclosed, protected space for things that matter.*

--- a/WHY.md
+++ b/WHY.md
@@ -1,6 +1,6 @@
 # Why Alcove exists
 
-*The word alcove comes from Arabic* القبة *(al-qubbah) — "the vault" — via Spanish* alcoba. *An enclosed, protected space for things that matter. That is the product.*
+*The word [alcove](https://en.wikipedia.org/wiki/Alcove) comes from Arabic* القبة *(al-qubbah) — "the vault" — via Spanish* alcoba. *An enclosed, protected space for things that matter. That is the product.*
 
 ## Index your world.
 


### PR DESCRIPTION
Closes #60.

Adds the etymology of *alcove* (from Arabic القبة, *al-qubbah*, "the vault") to two places:

- **WHY.md** — one line after the title, before the first section. Sets the philosophical tone before the product copy.
- **README.md** — colophon at the very bottom, after the license. Low-key, doesn't interrupt the flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation with etymological information explaining the origin of "alcove," tracing the term back to its Arabic roots (القبة, al-qubbah) meaning "the vault," and connections to the Spanish word "alcoba." Documentation now emphasizes the concept of an enclosed, protected space for important things.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->