### PR TITLE
Remove commit metadata policy from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,16 +96,6 @@ The full roadmap is in [docs/ROADMAP.md](docs/ROADMAP.md). Alcove will not becom
 
 [Why Alcove?](WHY.md) · [Architecture](docs/ARCHITECTURE.md) · [Operations](docs/OPERATIONS.md) · [Security](docs/SECURITY.md) · [Seed Corpus](docs/SEED_CORPUS.md) · [Roadmap](docs/ROADMAP.md) · [Plugin Ideas](docs/PLUGINS.md) · [Accessibility](ACCESSIBILITY.md)
 
-## Commit metadata policy
-
-`Co-authored-by:` trailers are blocked in this repository. Any commit message containing a `Co-authored-by:` trailer line will fail CI.
-
-Install local hooks to strip those lines before commit:
-
-```bash
-make hooks
-```
-
 ## License
 
 [Apache 2.0](LICENSE)


### PR DESCRIPTION
Removed commit metadata policy section regarding 'Co-authored-by' trailers and local hooks.

## What does this PR do?


## Why?


## How to test

- [ ] `pytest -q` passes
- [ ] No coverage regressions
- [ ] Manual verification (if applicable):

## Checklist

- [ ] Changes are scoped to one concern
- [ ] No secrets, PII, or hardcoded paths
- [ ] Docs updated (if user-facing behavior changed)

## Anything else?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the "Commit metadata policy" section from the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->