### PR TITLE
docs: mark Pro777/alcove as superseded

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> [!WARNING]
+> **DEPRECATED REPOSITORY**
+> `Pro777/alcove` is superseded by **`Spitfire-Cowboy/alcove`**.
+>
+> Canonical repo: https://github.com/Spitfire-Cowboy/alcove
+
 <img src="docs/assets/logo.svg" alt="Alcove" height="56">
 
 <p>
@@ -103,3 +109,4 @@ The full roadmap is in [docs/ROADMAP.md](docs/ROADMAP.md). Alcove will not becom
 ---
 
 *The word [alcove](https://en.wikipedia.org/wiki/Alcove_(architecture)) comes from Arabic* القبة *(al-qubbah) — "the vault." An enclosed, protected space for things that matter.*
+


### PR DESCRIPTION
This marks `Pro777/alcove` as deprecated and points users to the canonical repo.

Superseded by: https://github.com/Spitfire-Cowboy/alcove

Changes:
- Add deprecation warning banner at top of README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Repository marked as deprecated with a notice redirecting users to the new canonical location for continued support and development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->