### PR TITLE
Add runtime config feature flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to alcove-search.
 
+## [Unreleased]
+
+- Add runtime configuration feature flags for environment and config-file controlled deployments.
+
 ## [0.3.0] - 2026-03-07
 
 - Add theme toggle, fix WCAG AA contrast, update accessibility docs

--- a/alcove/config.py
+++ b/alcove/config.py
@@ -5,6 +5,11 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - exercised on Python 3.10
+    import tomli as tomllib
+
 
 @dataclass(frozen=True, slots=True)
 class Features:
@@ -125,15 +130,24 @@ def load_config() -> RuntimeConfig:
     )
 
 
-def set_private_mode(enabled: bool) -> None:
+def set_private_mode(*, enabled: bool) -> None:
     """Persist ``private_mode`` to an Alcove TOML config file."""
     path = Path(os.getenv("ALCOVE_CONFIG_PATH", "alcove.toml"))
     if path.suffix.lower() == ".json":
         raise ValueError("set_private_mode does not support JSON config files; use alcove.toml")
 
     value_str = "true" if enabled else "false"
-    if path.is_file():
-        lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    try:
+        exists = path.is_file()
+    except OSError as exc:
+        raise OSError(f"failed to inspect alcove config at {path}") from exc
+
+    if exists:
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+        except OSError as exc:
+            raise OSError(f"failed to read alcove config at {path}") from exc
+
         new_lines: list[str] = []
         replaced = False
         for line in lines:
@@ -147,9 +161,15 @@ def set_private_mode(enabled: bool) -> None:
             if new_lines and not new_lines[-1].endswith("\n"):
                 new_lines.append("\n")
             new_lines.append(f"private_mode = {value_str}\n")
-        path.write_text("".join(new_lines), encoding="utf-8")
+        try:
+            path.write_text("".join(new_lines), encoding="utf-8")
+        except OSError as exc:
+            raise OSError(f"failed to write alcove config at {path}") from exc
     else:
-        path.write_text(f"private_mode = {value_str}\n", encoding="utf-8")
+        try:
+            path.write_text(f"private_mode = {value_str}\n", encoding="utf-8")
+        except OSError as exc:
+            raise OSError(f"failed to write alcove config at {path}") from exc
 
 
 def _load_config_values() -> dict[str, object]:
@@ -188,40 +208,25 @@ def _load_json_values(path: Path) -> dict[str, object]:
 
 def _load_toml_values(path: Path) -> dict[str, object]:
     try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-    except OSError:
+        with path.open("rb") as fp:
+            data = tomllib.load(fp)
+    except (OSError, tomllib.TOMLDecodeError):
         return {}
 
     values: dict[str, object] = {}
-    current_section: tuple[str, ...] = ()
-    for raw_line in lines:
-        line = raw_line.split("#", 1)[0].strip()
-        if not line:
-            continue
-        if line.startswith("[") and line.endswith("]"):
-            current_section = tuple(part.strip() for part in line[1:-1].split(".") if part.strip())
-            continue
-        if "=" not in line:
-            continue
-
-        key, raw_value = (part.strip() for part in line.split("=", 1))
-        full_key = ".".join((*current_section, key)) if current_section else key
-        values[full_key] = _parse_scalar(raw_value)
+    _flatten_mapping(data, values=values)
     return values
 
 
-def _parse_scalar(raw_value: str) -> object:
-    if raw_value.startswith(("'", '"')) and raw_value.endswith(("'", '"')):
-        return raw_value[1:-1]
-
-    lowered = raw_value.lower()
-    if lowered in {"true", "false"}:
-        return lowered == "true"
-
-    try:
-        return int(raw_value)
-    except ValueError:
-        return raw_value
+def _flatten_mapping(
+    data: dict[str, object], *, values: dict[str, object], prefix: tuple[str, ...] = ()
+) -> None:
+    for key, value in data.items():
+        path = (*prefix, key)
+        if isinstance(value, dict):
+            _flatten_mapping(value, values=values, prefix=path)
+        else:
+            values[".".join(path)] = value
 
 
 def _resolve_bool(*, env_name: str, config_value: object, default: bool) -> bool:

--- a/alcove/config.py
+++ b/alcove/config.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class Features:
+    """Runtime feature flags.
+
+    Flags default to conservative values so unset local installs behave the
+    same as a fresh Alcove instance. Environment variables always override
+    config-file values.
+    """
+
+    recent_activity: bool = False
+    uploads: bool = True
+    auth: bool = False
+    turnstile: bool = False
+    keyword_mode: bool = False
+    date_filter: bool = False
+    score_filter: bool = False
+    project_filter: bool = False
+    attribution: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class Deployment:
+    """Deployment identity metadata."""
+
+    mode: str = "local"
+    instance_name: str = "Alcove"
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeConfig:
+    features: Features = field(default_factory=Features)
+    deployment: Deployment = field(default_factory=Deployment)
+    recent_activity_limit: int = 5
+    excerpt_chars: int | None = None
+    private_mode: bool = True
+
+
+def load_config() -> RuntimeConfig:
+    values = _load_config_values()
+    return RuntimeConfig(
+        features=Features(
+            recent_activity=_resolve_bool(
+                env_name="ALCOVE_FEATURE_RECENT_ACTIVITY",
+                config_value=values.get("features.recent_activity"),
+                default=False,
+            ),
+            uploads=_resolve_bool(
+                env_name="ALCOVE_ENABLE_UPLOADS",
+                config_value=values.get("features.uploads"),
+                default=True,
+            ),
+            auth=_resolve_bool(
+                env_name="ALCOVE_ENABLE_AUTH",
+                config_value=values.get("features.auth"),
+                default=False,
+            ),
+            turnstile=_resolve_bool(
+                env_name="ALCOVE_ENABLE_TURNSTILE",
+                config_value=values.get("features.turnstile"),
+                default=False,
+            ),
+            keyword_mode=_resolve_bool(
+                env_name="ALCOVE_ENABLE_KEYWORD_MODE",
+                config_value=values.get("features.keyword_mode"),
+                default=False,
+            ),
+            date_filter=_resolve_bool(
+                env_name="ALCOVE_ENABLE_DATE_FILTER",
+                config_value=values.get("features.date_filter"),
+                default=False,
+            ),
+            score_filter=_resolve_bool(
+                env_name="ALCOVE_ENABLE_SCORE_FILTER",
+                config_value=values.get("features.score_filter"),
+                default=False,
+            ),
+            project_filter=_resolve_bool(
+                env_name="ALCOVE_ENABLE_PROJECT_FILTER",
+                config_value=values.get("features.project_filter"),
+                default=False,
+            ),
+            attribution=_resolve_bool(
+                env_name="ALCOVE_ENABLE_ATTRIBUTION",
+                config_value=values.get("features.attribution"),
+                default=False,
+            ),
+        ),
+        deployment=Deployment(
+            mode=_resolve_str(
+                env_name="ALCOVE_DEPLOYMENT_MODE",
+                config_value=values.get("deployment.mode"),
+                default="local",
+                choices={"local", "demo", "hosted"},
+            ),
+            instance_name=_resolve_str(
+                env_name="ALCOVE_INSTANCE_NAME",
+                config_value=values.get("deployment.instance_name"),
+                default="Alcove",
+            ),
+        ),
+        recent_activity_limit=_resolve_int(
+            env_name="ALCOVE_RECENT_ACTIVITY_LIMIT",
+            config_value=values.get("features.recent_activity_limit"),
+            default=5,
+            minimum=1,
+        ),
+        excerpt_chars=_resolve_optional_int(
+            env_name="ALCOVE_EXCERPT_CHARS",
+            config_value=values.get("excerpt_chars"),
+            minimum=1,
+        ),
+        private_mode=_resolve_bool(
+            env_name="ALCOVE_PRIVATE",
+            config_value=values.get("private_mode"),
+            default=True,
+        ),
+    )
+
+
+def set_private_mode(enabled: bool) -> None:
+    """Persist ``private_mode`` to an Alcove TOML config file."""
+    path = Path(os.getenv("ALCOVE_CONFIG_PATH", "alcove.toml"))
+    if path.suffix.lower() == ".json":
+        raise ValueError("set_private_mode does not support JSON config files; use alcove.toml")
+
+    value_str = "true" if enabled else "false"
+    if path.is_file():
+        lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+        new_lines: list[str] = []
+        replaced = False
+        for line in lines:
+            stripped = line.split("#", 1)[0].strip()
+            if stripped.startswith("private_mode") and "=" in stripped:
+                new_lines.append(f"private_mode = {value_str}\n")
+                replaced = True
+            else:
+                new_lines.append(line)
+        if not replaced:
+            if new_lines and not new_lines[-1].endswith("\n"):
+                new_lines.append("\n")
+            new_lines.append(f"private_mode = {value_str}\n")
+        path.write_text("".join(new_lines), encoding="utf-8")
+    else:
+        path.write_text(f"private_mode = {value_str}\n", encoding="utf-8")
+
+
+def _load_config_values() -> dict[str, object]:
+    path = Path(os.getenv("ALCOVE_CONFIG_PATH", "alcove.toml"))
+    if not path.is_file():
+        return {}
+    if path.suffix.lower() == ".json":
+        return _load_json_values(path)
+    return _load_toml_values(path)
+
+
+def _load_json_values(path: Path) -> dict[str, object]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+    out: dict[str, object] = {}
+    features = data.get("features")
+    if isinstance(features, dict):
+        for key, value in features.items():
+            out[f"features.{key}"] = value
+
+    deployment = data.get("deployment")
+    if isinstance(deployment, dict):
+        for key, value in deployment.items():
+            out[f"deployment.{key}"] = value
+
+    if "excerpt_chars" in data:
+        out["excerpt_chars"] = data["excerpt_chars"]
+    if "private_mode" in data:
+        out["private_mode"] = data["private_mode"]
+
+    return out
+
+
+def _load_toml_values(path: Path) -> dict[str, object]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return {}
+
+    values: dict[str, object] = {}
+    current_section: tuple[str, ...] = ()
+    for raw_line in lines:
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            current_section = tuple(part.strip() for part in line[1:-1].split(".") if part.strip())
+            continue
+        if "=" not in line:
+            continue
+
+        key, raw_value = (part.strip() for part in line.split("=", 1))
+        full_key = ".".join((*current_section, key)) if current_section else key
+        values[full_key] = _parse_scalar(raw_value)
+    return values
+
+
+def _parse_scalar(raw_value: str) -> object:
+    if raw_value.startswith(("'", '"')) and raw_value.endswith(("'", '"')):
+        return raw_value[1:-1]
+
+    lowered = raw_value.lower()
+    if lowered in {"true", "false"}:
+        return lowered == "true"
+
+    try:
+        return int(raw_value)
+    except ValueError:
+        return raw_value
+
+
+def _resolve_bool(*, env_name: str, config_value: object, default: bool) -> bool:
+    env_value = os.getenv(env_name)
+    if env_value is not None:
+        parsed = _coerce_bool(env_value)
+        return default if parsed is None else parsed
+
+    parsed = _coerce_bool(config_value)
+    return default if parsed is None else parsed
+
+
+def _resolve_str(
+    *,
+    env_name: str,
+    config_value: object,
+    default: str,
+    choices: set[str] | None = None,
+) -> str:
+    env_value = os.getenv(env_name)
+    if env_value is not None:
+        value = env_value.strip()
+        if choices:
+            value = value.lower()
+            if value not in choices:
+                return default
+        return value
+
+    if isinstance(config_value, str):
+        value = config_value.strip()
+        if choices:
+            value = value.lower()
+            if value not in choices:
+                return default
+        return value
+
+    return default
+
+
+def _resolve_int(*, env_name: str, config_value: object, default: int, minimum: int) -> int:
+    env_value = os.getenv(env_name)
+    if env_value is not None:
+        parsed = _coerce_int(env_value)
+        return default if parsed is None else max(minimum, parsed)
+
+    parsed = _coerce_int(config_value)
+    return default if parsed is None else max(minimum, parsed)
+
+
+def _resolve_optional_int(*, env_name: str, config_value: object, minimum: int) -> int | None:
+    env_value = os.getenv(env_name)
+    if env_value is not None:
+        parsed = _coerce_int(env_value)
+        return None if parsed is None else max(minimum, parsed)
+
+    parsed = _coerce_int(config_value)
+    return None if parsed is None else max(minimum, parsed)
+
+
+def _coerce_bool(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return None
+
+
+def _coerce_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return None
+    return None

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,6 +20,8 @@ This is the foundation. Everything below builds on it.
 
 **Streaming ingest.** Watch a directory and re-index on change. The current pipeline is batch-oriented: you run `alcove ingest`, it processes everything. Streaming mode keeps the index current without manual intervention.
 
+**Runtime deployment controls.** Feature flags and deployment metadata should stay explicit, testable, and file-backed so public builds, local installs, and future hosted demos do not drift through ad hoc environment tweaks.
+
 ## Mid-term
 
 **Cross-modal indexing.** Audio transcription, image OCR, video keyframe extraction. The pipeline architecture already separates extraction from embedding; new modalities plug in as extractors that produce text chunks from non-text sources. Bioacoustics and field recordings are a motivating use case, not an afterthought.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "jinja2>=3.1,<4.0",
     "python-multipart>=0.0.6,<1.0",
     "rank-bm25>=0.2",
+    "tomli>=2.0,<3.0; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alcove.config import Deployment, Features, RuntimeConfig, load_config, set_private_mode
+
+
+def test_default_features_are_conservative():
+    features = Features()
+    assert features.uploads is True
+    assert features.auth is False
+    assert features.turnstile is False
+    assert features.keyword_mode is False
+    assert features.date_filter is False
+    assert features.score_filter is False
+    assert features.project_filter is False
+    assert features.attribution is False
+
+
+def test_default_deployment_identity():
+    deployment = Deployment()
+    assert deployment.mode == "local"
+    assert deployment.instance_name == "Alcove"
+
+
+def test_default_private_mode_is_true(monkeypatch):
+    monkeypatch.delenv("ALCOVE_PRIVATE", raising=False)
+    monkeypatch.delenv("ALCOVE_CONFIG_PATH", raising=False)
+    assert RuntimeConfig().private_mode is True
+    assert load_config().private_mode is True
+
+
+def test_env_bool_overrides(monkeypatch):
+    monkeypatch.delenv("ALCOVE_CONFIG_PATH", raising=False)
+    monkeypatch.setenv("ALCOVE_ENABLE_UPLOADS", "0")
+    monkeypatch.setenv("ALCOVE_ENABLE_AUTH", "1")
+    monkeypatch.setenv("ALCOVE_ENABLE_TURNSTILE", "true")
+    monkeypatch.setenv("ALCOVE_ENABLE_KEYWORD_MODE", "yes")
+    monkeypatch.setenv("ALCOVE_ENABLE_DATE_FILTER", "on")
+    monkeypatch.setenv("ALCOVE_ENABLE_SCORE_FILTER", "1")
+    monkeypatch.setenv("ALCOVE_ENABLE_PROJECT_FILTER", "true")
+    monkeypatch.setenv("ALCOVE_ENABLE_ATTRIBUTION", "yes")
+    monkeypatch.setenv("ALCOVE_PRIVATE", "false")
+
+    cfg = load_config()
+    assert cfg.features.uploads is False
+    assert cfg.features.auth is True
+    assert cfg.features.turnstile is True
+    assert cfg.features.keyword_mode is True
+    assert cfg.features.date_filter is True
+    assert cfg.features.score_filter is True
+    assert cfg.features.project_filter is True
+    assert cfg.features.attribution is True
+    assert cfg.private_mode is False
+
+
+def test_env_deployment_overrides(monkeypatch):
+    monkeypatch.delenv("ALCOVE_CONFIG_PATH", raising=False)
+    monkeypatch.setenv("ALCOVE_DEPLOYMENT_MODE", "demo")
+    monkeypatch.setenv("ALCOVE_INSTANCE_NAME", "Community Archive")
+
+    cfg = load_config()
+    assert cfg.deployment.mode == "demo"
+    assert cfg.deployment.instance_name == "Community Archive"
+
+
+def test_invalid_deployment_mode_falls_back(monkeypatch):
+    monkeypatch.delenv("ALCOVE_CONFIG_PATH", raising=False)
+    monkeypatch.setenv("ALCOVE_DEPLOYMENT_MODE", "cloud")
+
+    assert load_config().deployment.mode == "local"
+
+
+def test_numeric_env_overrides(monkeypatch):
+    monkeypatch.delenv("ALCOVE_CONFIG_PATH", raising=False)
+    monkeypatch.setenv("ALCOVE_RECENT_ACTIVITY_LIMIT", "12")
+    monkeypatch.setenv("ALCOVE_EXCERPT_CHARS", "350")
+
+    cfg = load_config()
+    assert cfg.recent_activity_limit == 12
+    assert cfg.excerpt_chars == 350
+
+
+def test_invalid_numeric_env_uses_defaults(monkeypatch):
+    monkeypatch.delenv("ALCOVE_CONFIG_PATH", raising=False)
+    monkeypatch.setenv("ALCOVE_RECENT_ACTIVITY_LIMIT", "many")
+    monkeypatch.setenv("ALCOVE_EXCERPT_CHARS", "wide")
+
+    cfg = load_config()
+    assert cfg.recent_activity_limit == 5
+    assert cfg.excerpt_chars is None
+
+
+def test_toml_feature_flags(tmp_path, monkeypatch):
+    toml = tmp_path / "alcove.toml"
+    toml.write_text(
+        "excerpt_chars = 250\n"
+        "private_mode = false\n"
+        "[features]\n"
+        "uploads = false\n"
+        "auth = true\n"
+        "keyword_mode = true\n"
+        "recent_activity_limit = 9\n"
+        "[deployment]\n"
+        'mode = "hosted"\n'
+        'instance_name = "My Archive"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(toml))
+    for env_name in (
+        "ALCOVE_ENABLE_UPLOADS",
+        "ALCOVE_ENABLE_AUTH",
+        "ALCOVE_ENABLE_KEYWORD_MODE",
+        "ALCOVE_DEPLOYMENT_MODE",
+        "ALCOVE_INSTANCE_NAME",
+        "ALCOVE_RECENT_ACTIVITY_LIMIT",
+        "ALCOVE_EXCERPT_CHARS",
+        "ALCOVE_PRIVATE",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
+
+    cfg = load_config()
+    assert cfg.features.uploads is False
+    assert cfg.features.auth is True
+    assert cfg.features.keyword_mode is True
+    assert cfg.recent_activity_limit == 9
+    assert cfg.deployment.mode == "hosted"
+    assert cfg.deployment.instance_name == "My Archive"
+    assert cfg.excerpt_chars == 250
+    assert cfg.private_mode is False
+
+
+def test_json_feature_flags(tmp_path, monkeypatch):
+    config_file = tmp_path / "alcove.json"
+    config_file.write_text(
+        json.dumps(
+            {
+                "features": {"uploads": False, "turnstile": True},
+                "deployment": {"mode": "hosted", "instance_name": "Demo Archive"},
+                "excerpt_chars": 120,
+                "private_mode": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(config_file))
+
+    cfg = load_config()
+    assert cfg.features.uploads is False
+    assert cfg.features.turnstile is True
+    assert cfg.deployment.mode == "hosted"
+    assert cfg.deployment.instance_name == "Demo Archive"
+    assert cfg.excerpt_chars == 120
+    assert cfg.private_mode is False
+
+
+def test_env_wins_over_config_file(tmp_path, monkeypatch):
+    toml = tmp_path / "alcove.toml"
+    toml.write_text("[features]\nuploads = false\n", encoding="utf-8")
+    monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(toml))
+    monkeypatch.setenv("ALCOVE_ENABLE_UPLOADS", "1")
+
+    assert load_config().features.uploads is True
+
+
+def test_config_objects_are_frozen(monkeypatch):
+    monkeypatch.delenv("ALCOVE_CONFIG_PATH", raising=False)
+    cfg = load_config()
+    with pytest.raises((AttributeError, TypeError)):
+        cfg.features.uploads = False  # type: ignore[misc]
+    with pytest.raises((AttributeError, TypeError)):
+        cfg.deployment.mode = "hosted"  # type: ignore[misc]
+
+
+def test_set_private_mode_creates_toml_when_file_missing(tmp_path, monkeypatch):
+    toml = tmp_path / "alcove.toml"
+    monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(toml))
+
+    set_private_mode(False)
+
+    assert toml.read_text(encoding="utf-8") == "private_mode = false\n"
+
+
+def test_set_private_mode_updates_existing_key(tmp_path, monkeypatch):
+    toml = tmp_path / "alcove.toml"
+    toml.write_text("private_mode = true\n", encoding="utf-8")
+    monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(toml))
+
+    set_private_mode(False)
+
+    assert toml.read_text(encoding="utf-8") == "private_mode = false\n"
+
+
+def test_set_private_mode_preserves_other_keys(tmp_path, monkeypatch):
+    toml = tmp_path / "alcove.toml"
+    toml.write_text("[features]\nuploads = true\n", encoding="utf-8")
+    monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(toml))
+
+    set_private_mode(True)
+
+    content = toml.read_text(encoding="utf-8")
+    assert "uploads = true" in content
+    assert "private_mode = true" in content
+
+
+def test_set_private_mode_rejects_json_config(tmp_path, monkeypatch):
+    config_file = tmp_path / "alcove.json"
+    config_file.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(config_file))
+
+    with pytest.raises(ValueError, match="JSON"):
+        set_private_mode(False)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+import alcove.config as config_module
 from alcove.config import Deployment, Features, RuntimeConfig, load_config, set_private_mode
 
 
@@ -143,10 +144,29 @@ def test_toml_feature_flags(tmp_path, monkeypatch):
     assert cfg.private_mode is False
 
 
+def test_toml_invalid_deployment_mode_falls_back(tmp_path, monkeypatch):
+    toml = tmp_path / "alcove.toml"
+    toml.write_text("[deployment]\nmode = \"cloud\"\n", encoding="utf-8")
+    monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(toml))
+    monkeypatch.delenv("ALCOVE_DEPLOYMENT_MODE", raising=False)
+
+    assert load_config().deployment.mode == "local"
+
+
 def test_invalid_toml_config_is_ignored(tmp_path, monkeypatch):
     toml = tmp_path / "alcove.toml"
     toml.write_text("[features\nuploads = false\n", encoding="utf-8")
     monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(toml))
+
+    cfg = load_config()
+    assert cfg.features.uploads is True
+    assert cfg.private_mode is True
+
+
+def test_invalid_json_config_is_ignored(tmp_path, monkeypatch):
+    config_file = tmp_path / "alcove.json"
+    config_file.write_text("{", encoding="utf-8")
+    monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(config_file))
 
     cfg = load_config()
     assert cfg.features.uploads is True
@@ -175,6 +195,19 @@ def test_json_feature_flags(tmp_path, monkeypatch):
     assert cfg.deployment.instance_name == "Demo Archive"
     assert cfg.excerpt_chars == 120
     assert cfg.private_mode is False
+
+
+def test_json_numeric_values_can_be_booleans(tmp_path, monkeypatch):
+    config_file = tmp_path / "alcove.json"
+    config_file.write_text(
+        json.dumps({"features": {"recent_activity": 1, "recent_activity_limit": True}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(config_file))
+
+    cfg = load_config()
+    assert cfg.features.recent_activity is True
+    assert cfg.recent_activity_limit == 1
 
 
 def test_env_wins_over_config_file(tmp_path, monkeypatch):
@@ -226,10 +259,78 @@ def test_set_private_mode_preserves_other_keys(tmp_path, monkeypatch):
     assert "private_mode = true" in content
 
 
+def test_set_private_mode_appends_after_file_without_newline(tmp_path, monkeypatch):
+    toml = tmp_path / "alcove.toml"
+    toml.write_text("[features]\nuploads = true", encoding="utf-8")
+    monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(toml))
+
+    set_private_mode(enabled=False)
+
+    assert toml.read_text(encoding="utf-8").endswith("uploads = true\nprivate_mode = false\n")
+
+
 def test_set_private_mode_rejects_json_config(tmp_path, monkeypatch):
     config_file = tmp_path / "alcove.json"
     config_file.write_text("{}", encoding="utf-8")
     monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(config_file))
 
     with pytest.raises(ValueError, match="JSON"):
+        set_private_mode(enabled=False)
+
+
+def test_set_private_mode_wraps_inspect_errors(tmp_path, monkeypatch):
+    toml = tmp_path / "alcove.toml"
+    monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(toml))
+
+    def raise_os_error(self):
+        raise OSError("boom")
+
+    monkeypatch.setattr(config_module.Path, "is_file", raise_os_error)
+
+    with pytest.raises(OSError, match="failed to inspect alcove config"):
+        set_private_mode(enabled=False)
+
+
+def test_set_private_mode_wraps_read_errors(tmp_path, monkeypatch):
+    toml = tmp_path / "alcove.toml"
+    toml.write_text("private_mode = true\n", encoding="utf-8")
+    monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(toml))
+
+    original_read_text = config_module.Path.read_text
+
+    def raise_on_config(self, *args, **kwargs):
+        if self == toml:
+            raise OSError("boom")
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(config_module.Path, "read_text", raise_on_config)
+
+    with pytest.raises(OSError, match="failed to read alcove config"):
+        set_private_mode(enabled=False)
+
+
+def test_set_private_mode_wraps_existing_file_write_errors(tmp_path, monkeypatch):
+    toml = tmp_path / "alcove.toml"
+    toml.write_text("private_mode = true\n", encoding="utf-8")
+    monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(toml))
+
+    def raise_os_error(self, *args, **kwargs):
+        raise OSError("boom")
+
+    monkeypatch.setattr(config_module.Path, "write_text", raise_os_error)
+
+    with pytest.raises(OSError, match="failed to write alcove config"):
+        set_private_mode(enabled=False)
+
+
+def test_set_private_mode_wraps_new_file_write_errors(tmp_path, monkeypatch):
+    toml = tmp_path / "alcove.toml"
+    monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(toml))
+
+    def raise_os_error(self, *args, **kwargs):
+        raise OSError("boom")
+
+    monkeypatch.setattr(config_module.Path, "write_text", raise_os_error)
+
+    with pytest.raises(OSError, match="failed to write alcove config"):
         set_private_mode(enabled=False)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,8 +4,7 @@ import json
 
 import pytest
 
-import alcove.config as config_module
-from alcove.config import Deployment, Features, RuntimeConfig, load_config, set_private_mode
+from alcove.config import Deployment, Features, Path as ConfigPath, RuntimeConfig, load_config, set_private_mode
 
 
 def test_default_features_are_conservative():
@@ -285,7 +284,7 @@ def test_set_private_mode_wraps_inspect_errors(tmp_path, monkeypatch):
     def raise_os_error(self):
         raise OSError("boom")
 
-    monkeypatch.setattr(config_module.Path, "is_file", raise_os_error)
+    monkeypatch.setattr(ConfigPath, "is_file", raise_os_error)
 
     with pytest.raises(OSError, match="failed to inspect alcove config"):
         set_private_mode(enabled=False)
@@ -296,14 +295,14 @@ def test_set_private_mode_wraps_read_errors(tmp_path, monkeypatch):
     toml.write_text("private_mode = true\n", encoding="utf-8")
     monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(toml))
 
-    original_read_text = config_module.Path.read_text
+    original_read_text = ConfigPath.read_text
 
     def raise_on_config(self, *args, **kwargs):
         if self == toml:
             raise OSError("boom")
         return original_read_text(self, *args, **kwargs)
 
-    monkeypatch.setattr(config_module.Path, "read_text", raise_on_config)
+    monkeypatch.setattr(ConfigPath, "read_text", raise_on_config)
 
     with pytest.raises(OSError, match="failed to read alcove config"):
         set_private_mode(enabled=False)
@@ -317,7 +316,7 @@ def test_set_private_mode_wraps_existing_file_write_errors(tmp_path, monkeypatch
     def raise_os_error(self, *args, **kwargs):
         raise OSError("boom")
 
-    monkeypatch.setattr(config_module.Path, "write_text", raise_os_error)
+    monkeypatch.setattr(ConfigPath, "write_text", raise_os_error)
 
     with pytest.raises(OSError, match="failed to write alcove config"):
         set_private_mode(enabled=False)
@@ -330,7 +329,7 @@ def test_set_private_mode_wraps_new_file_write_errors(tmp_path, monkeypatch):
     def raise_os_error(self, *args, **kwargs):
         raise OSError("boom")
 
-    monkeypatch.setattr(config_module.Path, "write_text", raise_os_error)
+    monkeypatch.setattr(ConfigPath, "write_text", raise_os_error)
 
     with pytest.raises(OSError, match="failed to write alcove config"):
         set_private_mode(enabled=False)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ from alcove.config import Deployment, Features, RuntimeConfig, load_config, set_
 
 def test_default_features_are_conservative():
     features = Features()
+    assert features.recent_activity is False
     assert features.uploads is True
     assert features.auth is False
     assert features.turnstile is False
@@ -93,6 +94,16 @@ def test_invalid_numeric_env_uses_defaults(monkeypatch):
     assert cfg.excerpt_chars is None
 
 
+def test_numeric_env_clamps_to_minimum(monkeypatch):
+    monkeypatch.delenv("ALCOVE_CONFIG_PATH", raising=False)
+    monkeypatch.setenv("ALCOVE_RECENT_ACTIVITY_LIMIT", "0")
+    monkeypatch.setenv("ALCOVE_EXCERPT_CHARS", "-100")
+
+    cfg = load_config()
+    assert cfg.recent_activity_limit == 1
+    assert cfg.excerpt_chars == 1
+
+
 def test_toml_feature_flags(tmp_path, monkeypatch):
     toml = tmp_path / "alcove.toml"
     toml.write_text(
@@ -130,6 +141,16 @@ def test_toml_feature_flags(tmp_path, monkeypatch):
     assert cfg.deployment.instance_name == "My Archive"
     assert cfg.excerpt_chars == 250
     assert cfg.private_mode is False
+
+
+def test_invalid_toml_config_is_ignored(tmp_path, monkeypatch):
+    toml = tmp_path / "alcove.toml"
+    toml.write_text("[features\nuploads = false\n", encoding="utf-8")
+    monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(toml))
+
+    cfg = load_config()
+    assert cfg.features.uploads is True
+    assert cfg.private_mode is True
 
 
 def test_json_feature_flags(tmp_path, monkeypatch):
@@ -178,7 +199,7 @@ def test_set_private_mode_creates_toml_when_file_missing(tmp_path, monkeypatch):
     toml = tmp_path / "alcove.toml"
     monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(toml))
 
-    set_private_mode(False)
+    set_private_mode(enabled=False)
 
     assert toml.read_text(encoding="utf-8") == "private_mode = false\n"
 
@@ -188,7 +209,7 @@ def test_set_private_mode_updates_existing_key(tmp_path, monkeypatch):
     toml.write_text("private_mode = true\n", encoding="utf-8")
     monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(toml))
 
-    set_private_mode(False)
+    set_private_mode(enabled=False)
 
     assert toml.read_text(encoding="utf-8") == "private_mode = false\n"
 
@@ -198,7 +219,7 @@ def test_set_private_mode_preserves_other_keys(tmp_path, monkeypatch):
     toml.write_text("[features]\nuploads = true\n", encoding="utf-8")
     monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(toml))
 
-    set_private_mode(True)
+    set_private_mode(enabled=True)
 
     content = toml.read_text(encoding="utf-8")
     assert "uploads = true" in content
@@ -211,4 +232,4 @@ def test_set_private_mode_rejects_json_config(tmp_path, monkeypatch):
     monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(config_file))
 
     with pytest.raises(ValueError, match="JSON"):
-        set_private_mode(False)
+        set_private_mode(enabled=False)


### PR DESCRIPTION
Summary
- add a public-safe runtime config module for env-driven and file-driven feature flags
- support deployment identity, private-mode defaults, result excerpt sizing, and recent activity limits
- add focused tests for defaults, env overrides, TOML/JSON config loading, immutability, and private-mode persistence

Why
This is the first extraction PR from alcove-private into the public repo. It creates the stable configuration layer needed by the next public feature PRs without moving private deployment, Sentry, watchdog, or customer-specific code.

Privacy review
- no private repo slugs, local paths, hostnames, customer names, or internal deployment details added
- examples use generic archive names only

Verification
- python3 -m pytest tests/test_config.py -q
- python3 -m pytest -q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable feature flags including recent activity, uploads, authentication, and filtering options
  * Introduced deployment configuration for mode and instance naming
  * Added private mode toggle for enhanced privacy control
  * Configuration now supports environment variable overrides for flexible runtime adjustments

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Spitfire-Cowboy/alcove/pull/117)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->