### PR TITLE
Add index provenance signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to alcove-search.
 
+## [Unreleased]
+
+- Add local Ed25519 signing helpers and a standalone index signing tool for provenance checks.
+
 ## [0.3.0] - 2026-03-07
 
 - Add theme toggle, fix WCAG AA contrast, update accessibility docs

--- a/alcove/signer.py
+++ b/alcove/signer.py
@@ -9,6 +9,7 @@ band.
 from __future__ import annotations
 
 import base64
+import contextlib
 import datetime
 import hashlib
 import os
@@ -72,10 +73,8 @@ class InstanceSigner:
             with os.fdopen(fd, "wb") as f:
                 f.write(signer.private_key_pem())
         except Exception:
-            try:
+            with contextlib.suppress(FileNotFoundError):
                 path.unlink()
-            except FileNotFoundError:
-                pass
             raise
         return signer
 

--- a/alcove/signer.py
+++ b/alcove/signer.py
@@ -1,0 +1,152 @@
+"""Signing helpers for Alcove provenance metadata.
+
+This module provides local Ed25519 signing primitives for document and index
+provenance. Signatures prove that bytes match a specific public key; callers
+that need identity trust must pin or verify the public-key fingerprint out of
+band.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime
+import hashlib
+import os
+from pathlib import Path
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+    load_pem_private_key,
+    load_pem_public_key,
+)
+
+
+def document_hash(data: bytes) -> str:
+    """Return the canonical SHA-256 digest string for *data*."""
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+class InstanceSigner:
+    """Ed25519 signing context for one local Alcove instance."""
+
+    def __init__(
+        self,
+        private_key: Ed25519PrivateKey | None,
+        public_key: Ed25519PublicKey | None = None,
+    ) -> None:
+        self._private_key = private_key
+        if public_key is not None:
+            self._public_key = public_key
+        elif private_key is not None:
+            self._public_key = private_key.public_key()
+        else:
+            raise ValueError("private_key or public_key is required")
+
+    @classmethod
+    def generate(cls) -> "InstanceSigner":
+        """Generate a fresh Ed25519 keypair."""
+        return cls(Ed25519PrivateKey.generate())
+
+    @classmethod
+    def load_or_create(cls, key_path: str | Path) -> "InstanceSigner":
+        """Load an Ed25519 private key, or create one with mode 0600."""
+        path = Path(key_path)
+        if path.is_file():
+            private_key = load_pem_private_key(path.read_bytes(), password=None)
+            if not isinstance(private_key, Ed25519PrivateKey):
+                raise ValueError(f"{key_path}: expected Ed25519 private key")
+            return cls(private_key)
+
+        signer = cls.generate()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        fd = os.open(path, flags, 0o600)
+        try:
+            with os.fdopen(fd, "wb") as f:
+                f.write(signer.private_key_pem())
+        except Exception:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+            raise
+        return signer
+
+    @classmethod
+    def from_public_key_pem(cls, pem: bytes | str) -> "InstanceSigner":
+        """Create a verification-only signer from an Ed25519 public key PEM."""
+        if isinstance(pem, str):
+            pem = pem.encode("utf-8")
+        public_key = load_pem_public_key(pem)
+        if not isinstance(public_key, Ed25519PublicKey):
+            raise ValueError("expected Ed25519 public key")
+        return cls(private_key=None, public_key=public_key)
+
+    def private_key_pem(self) -> bytes:
+        """Return the private key in PEM-encoded PKCS8 format."""
+        if self._private_key is None:
+            raise RuntimeError("no private key available")
+        return self._private_key.private_bytes(
+            encoding=Encoding.PEM,
+            format=PrivateFormat.PKCS8,
+            encryption_algorithm=NoEncryption(),
+        )
+
+    def public_key_pem(self) -> bytes:
+        """Return the public key in PEM-encoded SubjectPublicKeyInfo format."""
+        return self._public_key.public_bytes(
+            encoding=Encoding.PEM,
+            format=PublicFormat.SubjectPublicKeyInfo,
+        )
+
+    def fingerprint(self) -> str:
+        """Return the first 16 bytes of the raw public key as hex."""
+        raw = self._public_key.public_bytes(
+            encoding=Encoding.Raw,
+            format=PublicFormat.Raw,
+        )
+        return raw[:16].hex()
+
+    def sign(self, data: bytes) -> str:
+        """Sign *data* and return a URL-safe base64 signature."""
+        if self._private_key is None:
+            raise RuntimeError("no private key available")
+        signature = self._private_key.sign(data)
+        return base64.urlsafe_b64encode(signature).decode("ascii")
+
+    def verify(self, data: bytes, signature_b64: str) -> bool:
+        """Return whether *signature_b64* is valid for *data*."""
+        try:
+            signature = base64.urlsafe_b64decode(signature_b64)
+            self._public_key.verify(signature, data)
+        except Exception:
+            return False
+        return True
+
+    def sign_document(
+        self,
+        data: bytes,
+        *,
+        signed_at: str | None = None,
+    ) -> dict[str, str]:
+        """Return ChromaDB-ready signature metadata for document bytes."""
+        digest = document_hash(data)
+        timestamp = signed_at or datetime.datetime.now(datetime.timezone.utc).isoformat()
+        return {
+            "doc_hash": digest,
+            "doc_signature": self.sign(digest.encode("utf-8")),
+            "signed_at": timestamp,
+            "instance_key": self.fingerprint(),
+        }
+
+    def verify_document(self, data: bytes, signature_b64: str) -> bool:
+        """Verify a document signature over the canonical document hash."""
+        digest = document_hash(data)
+        return self.verify(digest.encode("utf-8"), signature_b64)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,6 +20,8 @@ This is the foundation. Everything below builds on it.
 
 **Streaming ingest.** Watch a directory and re-index on change. The current pipeline is batch-oriented: you run `alcove ingest`, it processes everything. Streaming mode keeps the index current without manual intervention.
 
+**Provenance and index signing.** Local signing should let operators publish or move index exports with tamper-evident metadata. The first step is Ed25519 signing and verification for document hashes and index export envelopes. Signature verification proves integrity against a public key; identity trust still depends on the operator pinning or verifying the key fingerprint out of band.
+
 ## Mid-term
 
 **Cross-modal indexing.** Audio transcription, image OCR, video keyframe extraction. The pipeline architecture already separates extraction from embedding; new modalities plug in as extractors that produce text chunks from non-text sources. Bioacoustics and field recordings are a motivating use case, not an afterthought.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "jinja2>=3.1,<4.0",
     "python-multipart>=0.0.6,<1.0",
     "rank-bm25>=0.2",
+    "cryptography>=41.0,<47.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_index_sign.py
+++ b/tests/test_index_sign.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import stat
+import sys
+from pathlib import Path
+
+
+_SCRIPT = Path(__file__).parent.parent / "tools" / "index-sign" / "sign.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("index_sign", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["index_sign"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+_mod = _load_module()
+sign_index = _mod.sign_index
+verify_signed_index = _mod.verify_signed_index
+SIGNED_INDEX_VERSION = _mod.SIGNED_INDEX_VERSION
+
+
+_SAMPLE_INDEX = {
+    "alcove_sync_version": 1,
+    "exported_at": "2026-01-01T00:00:00+00:00",
+    "collections": {
+        "docs": {
+            "ids": ["a", "b"],
+            "documents": ["doc a", "doc b"],
+            "metadatas": [{"source": "a.md"}, {"source": "b.md"}],
+            "embeddings": [[0.1, 0.2], [0.3, 0.4]],
+        }
+    },
+}
+
+
+def test_sign_index_returns_versioned_envelope_and_creates_key(tmp_path) -> None:
+    key_path = tmp_path / "alcove.key"
+    envelope = sign_index(_SAMPLE_INDEX, key_path, signed_at="2026-01-01T00:00:00+00:00")
+
+    assert envelope["alcove_signed_index_version"] == SIGNED_INDEX_VERSION
+    assert envelope["signed_at"] == "2026-01-01T00:00:00+00:00"
+    assert envelope["index"] == _SAMPLE_INDEX
+    assert envelope["index_hash"].startswith("sha256:")
+    assert "PUBLIC KEY" in envelope["signer_public_key_pem"]
+    assert key_path.is_file()
+    assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+
+
+def test_sign_index_rejects_unsupported_index_export_version(tmp_path) -> None:
+    index = dict(_SAMPLE_INDEX, alcove_sync_version=2)
+
+    try:
+        sign_index(index, tmp_path / "alcove.key")
+    except ValueError as exc:
+        assert "alcove_sync_version 1" in str(exc)
+    else:
+        raise AssertionError("expected sign_index to reject unsupported export version")
+
+
+def test_verify_signed_index_accepts_valid_envelope(tmp_path) -> None:
+    envelope = sign_index(_SAMPLE_INDEX, tmp_path / "alcove.key")
+    assert verify_signed_index(envelope) is True
+
+
+def test_verify_signed_index_rejects_unsupported_or_missing_version(tmp_path) -> None:
+    envelope = sign_index(_SAMPLE_INDEX, tmp_path / "alcove.key")
+    envelope["alcove_signed_index_version"] = 99
+    assert verify_signed_index(envelope) is False
+
+    del envelope["alcove_signed_index_version"]
+    assert verify_signed_index(envelope) is False
+
+
+def test_verify_signed_index_rejects_tampering(tmp_path) -> None:
+    envelope = sign_index(_SAMPLE_INDEX, tmp_path / "alcove.key")
+    envelope["index"]["collections"]["docs"]["ids"].append("injected")
+    assert verify_signed_index(envelope) is False
+
+
+def test_verify_signed_index_rejects_hash_signature_key_and_fingerprint_changes(tmp_path) -> None:
+    envelope = sign_index(_SAMPLE_INDEX, tmp_path / "alcove.key")
+
+    bad_hash = dict(envelope, index_hash="sha256:" + "a" * 64)
+    assert verify_signed_index(bad_hash) is False
+
+    bad_signature = dict(envelope, index_signature="AAAA")
+    assert verify_signed_index(bad_signature) is False
+
+    bad_key = dict(envelope, signer_public_key_pem="not-a-pem")
+    assert verify_signed_index(bad_key) is False
+
+    bad_fingerprint = dict(envelope, signer_fingerprint="0" * 32)
+    assert verify_signed_index(bad_fingerprint) is False
+
+
+def test_cli_sign_verify_and_export_pubkey(tmp_path) -> None:
+    index_path = tmp_path / "dump.json"
+    signed_path = tmp_path / "dump.signed.json"
+    key_path = tmp_path / "alcove.key"
+    pubkey_path = tmp_path / "pubkey.pem"
+    index_path.write_text(json.dumps(_SAMPLE_INDEX))
+
+    assert _mod.main(["sign", "--index", str(index_path), "--key", str(key_path), "--out", str(signed_path)]) == 0
+    assert signed_path.is_file()
+    assert verify_signed_index(json.loads(signed_path.read_text()))
+
+    assert _mod.main(["verify", "--signed", str(signed_path)]) == 0
+    assert _mod.main(["export-pubkey", "--key", str(key_path), "--out", str(pubkey_path)]) == 0
+    assert b"PUBLIC KEY" in pubkey_path.read_bytes()
+
+
+def test_cli_missing_files_return_nonzero(tmp_path) -> None:
+    assert _mod.main(["sign", "--index", str(tmp_path / "missing.json"), "--key", str(tmp_path / "k"), "--out", str(tmp_path / "o")]) != 0
+    assert _mod.main(["verify", "--signed", str(tmp_path / "missing.signed.json")]) != 0
+    assert _mod.main(["export-pubkey", "--key", str(tmp_path / "missing.key"), "--out", str(tmp_path / "pub.pem")]) != 0

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -5,6 +5,13 @@ import hashlib
 import stat
 
 import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+)
 
 from alcove.signer import InstanceSigner, document_hash
 
@@ -17,6 +24,11 @@ def test_document_hash_is_canonical_sha256() -> None:
 
 def test_generated_signers_have_different_keys() -> None:
     assert InstanceSigner.generate().public_key_pem() != InstanceSigner.generate().public_key_pem()
+
+
+def test_signer_requires_private_or_public_key() -> None:
+    with pytest.raises(ValueError, match="private_key or public_key"):
+        InstanceSigner(None)
 
 
 def test_key_serialization_and_fingerprint() -> None:
@@ -38,6 +50,50 @@ def test_load_or_create_persists_generated_key_with_0600_mode(tmp_path) -> None:
     assert signer.public_key_pem() == loaded.public_key_pem()
 
 
+def test_load_or_create_rejects_non_ed25519_private_key(tmp_path) -> None:
+    key_path = tmp_path / "rsa.key"
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    key_path.write_bytes(
+        key.private_bytes(
+            encoding=Encoding.PEM,
+            format=PrivateFormat.PKCS8,
+            encryption_algorithm=NoEncryption(),
+        )
+    )
+
+    with pytest.raises(ValueError, match="expected Ed25519 private key"):
+        InstanceSigner.load_or_create(key_path)
+
+
+def test_load_or_create_removes_partial_key_on_write_failure(tmp_path, monkeypatch) -> None:
+    key_path = tmp_path / "alcove.key"
+
+    def fail_private_key_pem(self):
+        raise RuntimeError("write failed")
+
+    monkeypatch.setattr(InstanceSigner, "private_key_pem", fail_private_key_pem)
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        InstanceSigner.load_or_create(key_path)
+    assert not key_path.exists()
+
+
+def test_load_or_create_ignores_missing_partial_key_on_cleanup(tmp_path, monkeypatch) -> None:
+    key_path = tmp_path / "alcove.key"
+
+    def fail_private_key_pem(self):
+        raise RuntimeError("write failed")
+
+    def missing_unlink(self):
+        raise FileNotFoundError
+
+    monkeypatch.setattr(InstanceSigner, "private_key_pem", fail_private_key_pem)
+    monkeypatch.setattr(type(key_path), "unlink", missing_unlink)
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        InstanceSigner.load_or_create(key_path)
+
+
 def test_public_key_pem_creates_verify_only_signer() -> None:
     signer = InstanceSigner.generate()
     verifier = InstanceSigner.from_public_key_pem(signer.public_key_pem().decode("utf-8"))
@@ -51,6 +107,17 @@ def test_public_key_pem_creates_verify_only_signer() -> None:
 def test_rejects_invalid_public_key_pem() -> None:
     with pytest.raises(Exception):
         InstanceSigner.from_public_key_pem(b"not-valid-pem")
+
+
+def test_rejects_non_ed25519_public_key_pem() -> None:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_pem = key.public_key().public_bytes(
+        encoding=Encoding.PEM,
+        format=PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    with pytest.raises(ValueError, match="expected Ed25519 public key"):
+        InstanceSigner.from_public_key_pem(public_pem)
 
 
 def test_sign_and_verify_bytes() -> None:

--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import stat
+
+import pytest
+
+from alcove.signer import InstanceSigner, document_hash
+
+
+def test_document_hash_is_canonical_sha256() -> None:
+    assert document_hash(b"") == "sha256:" + hashlib.sha256(b"").hexdigest()
+    assert document_hash(b"data").startswith("sha256:")
+    assert document_hash(b"a") != document_hash(b"b")
+
+
+def test_generated_signers_have_different_keys() -> None:
+    assert InstanceSigner.generate().public_key_pem() != InstanceSigner.generate().public_key_pem()
+
+
+def test_key_serialization_and_fingerprint() -> None:
+    signer = InstanceSigner.generate()
+    assert b"PRIVATE KEY" in signer.private_key_pem()
+    assert b"PUBLIC KEY" in signer.public_key_pem()
+    fingerprint = signer.fingerprint()
+    assert len(fingerprint) == 32
+    int(fingerprint, 16)
+
+
+def test_load_or_create_persists_generated_key_with_0600_mode(tmp_path) -> None:
+    key_path = tmp_path / "keys" / "alcove.key"
+    signer = InstanceSigner.load_or_create(key_path)
+    loaded = InstanceSigner.load_or_create(key_path)
+
+    assert key_path.is_file()
+    assert stat.S_IMODE(key_path.stat().st_mode) == 0o600
+    assert signer.public_key_pem() == loaded.public_key_pem()
+
+
+def test_public_key_pem_creates_verify_only_signer() -> None:
+    signer = InstanceSigner.generate()
+    verifier = InstanceSigner.from_public_key_pem(signer.public_key_pem().decode("utf-8"))
+
+    with pytest.raises(RuntimeError):
+        verifier.private_key_pem()
+    with pytest.raises(RuntimeError):
+        verifier.sign(b"data")
+
+
+def test_rejects_invalid_public_key_pem() -> None:
+    with pytest.raises(Exception):
+        InstanceSigner.from_public_key_pem(b"not-valid-pem")
+
+
+def test_sign_and_verify_bytes() -> None:
+    signer = InstanceSigner.generate()
+    signature = signer.sign(b"hello")
+
+    base64.urlsafe_b64decode(signature)
+    assert signer.verify(b"hello", signature)
+    assert not signer.verify(b"tampered", signature)
+    assert not InstanceSigner.generate().verify(b"hello", signature)
+    assert not signer.verify(b"hello", "not-a-real-signature==")
+
+
+def test_sign_document_metadata_and_verification() -> None:
+    signer = InstanceSigner.generate()
+    data = b"document bytes"
+    metadata = signer.sign_document(data, signed_at="2026-01-01T00:00:00+00:00")
+
+    assert metadata == {
+        "doc_hash": document_hash(data),
+        "doc_signature": metadata["doc_signature"],
+        "signed_at": "2026-01-01T00:00:00+00:00",
+        "instance_key": signer.fingerprint(),
+    }
+    assert signer.verify_document(data, metadata["doc_signature"])
+    assert not signer.verify_document(b"tampered", metadata["doc_signature"])
+
+
+def test_verify_document_with_public_key_only() -> None:
+    signer = InstanceSigner.generate()
+    metadata = signer.sign_document(b"document")
+    verifier = InstanceSigner.from_public_key_pem(signer.public_key_pem())
+
+    assert verifier.verify_document(b"document", metadata["doc_signature"])

--- a/tools/index-sign/sign.py
+++ b/tools/index-sign/sign.py
@@ -1,0 +1,167 @@
+"""Sign and verify Alcove index export envelopes."""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from alcove.signer import InstanceSigner, document_hash  # noqa: E402
+
+
+SIGNED_INDEX_VERSION = 1
+
+
+def _canonical_index_bytes(index: dict[str, Any]) -> bytes:
+    return json.dumps(index, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def sign_index(
+    index: dict[str, Any],
+    key_path: Path,
+    *,
+    signed_at: str | None = None,
+) -> dict[str, Any]:
+    """Return a signed-index envelope for an Alcove index export."""
+    if index.get("alcove_sync_version") != 1:
+        raise ValueError("index export must use alcove_sync_version 1")
+
+    signer = InstanceSigner.load_or_create(key_path)
+    index_hash = document_hash(_canonical_index_bytes(index))
+    timestamp = signed_at or datetime.datetime.now(datetime.timezone.utc).isoformat()
+    return {
+        "alcove_signed_index_version": SIGNED_INDEX_VERSION,
+        "signed_at": timestamp,
+        "signer_fingerprint": signer.fingerprint(),
+        "signer_public_key_pem": signer.public_key_pem().decode("utf-8"),
+        "index_hash": index_hash,
+        "index_signature": signer.sign(index_hash.encode("utf-8")),
+        "index": index,
+    }
+
+
+def verify_signed_index(envelope: dict[str, Any]) -> bool:
+    """Verify envelope integrity and signature.
+
+    This checks that the envelope version is supported, the index payload
+    matches the stored hash, and the signature validates with the embedded
+    public key. It does not establish identity trust; callers that care who
+    signed the index must pin or verify the key fingerprint out of band.
+    """
+    if envelope.get("alcove_signed_index_version") != SIGNED_INDEX_VERSION:
+        return False
+
+    index = envelope.get("index")
+    index_hash = envelope.get("index_hash")
+    signature = envelope.get("index_signature")
+    public_key_pem = envelope.get("signer_public_key_pem")
+    fingerprint = envelope.get("signer_fingerprint")
+    if not isinstance(index, dict):
+        return False
+    if not all(isinstance(value, str) for value in (index_hash, signature, public_key_pem, fingerprint)):
+        return False
+
+    expected_hash = document_hash(_canonical_index_bytes(index))
+    if expected_hash != index_hash:
+        return False
+
+    try:
+        verifier = InstanceSigner.from_public_key_pem(public_key_pem)
+    except Exception:
+        return False
+
+    if verifier.fingerprint() != fingerprint:
+        return False
+    return verifier.verify(index_hash.encode("utf-8"), signature)
+
+
+def _cmd_sign(args: argparse.Namespace) -> int:
+    index_path = Path(args.index)
+    if not index_path.is_file():
+        print(f"error: index file not found: {index_path}", file=sys.stderr)
+        return 1
+
+    index = json.loads(index_path.read_text())
+    envelope = sign_index(index, Path(args.key))
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(envelope, indent=2) + "\n")
+    print(f"signed: {out_path}")
+    print(f"  fingerprint : {envelope['signer_fingerprint']}")
+    print(f"  index_hash  : {envelope['index_hash']}")
+    return 0
+
+
+def _cmd_verify(args: argparse.Namespace) -> int:
+    signed_path = Path(args.signed)
+    if not signed_path.is_file():
+        print(f"error: signed index not found: {signed_path}", file=sys.stderr)
+        return 1
+
+    envelope = json.loads(signed_path.read_text())
+    if verify_signed_index(envelope):
+        print(f"OK  {signed_path}")
+        print(f"    fingerprint : {envelope.get('signer_fingerprint', '?')}")
+        print(f"    signed_at   : {envelope.get('signed_at', '?')}")
+        return 0
+
+    print(f"FAIL  {signed_path}  (signature invalid or index tampered)", file=sys.stderr)
+    return 2
+
+
+def _cmd_export_pubkey(args: argparse.Namespace) -> int:
+    key_path = Path(args.key)
+    if not key_path.is_file():
+        print(f"error: key file not found: {key_path}", file=sys.stderr)
+        return 1
+
+    signer = InstanceSigner.load_or_create(key_path)
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_bytes(signer.public_key_pem())
+    print(f"public key written: {out_path}")
+    print(f"  fingerprint: {signer.fingerprint()}")
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Sign and verify Alcove index exports.")
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    sign_parser = subcommands.add_parser("sign", help="Sign an index dump.")
+    sign_parser.add_argument("--index", required=True, help="Path to the index export JSON.")
+    sign_parser.add_argument("--key", required=True, help="Path to the Ed25519 private key PEM.")
+    sign_parser.add_argument("--out", required=True, help="Output path for the signed JSON envelope.")
+
+    verify_parser = subcommands.add_parser("verify", help="Verify a signed index.")
+    verify_parser.add_argument("--signed", required=True, help="Path to the signed index JSON.")
+
+    export_parser = subcommands.add_parser("export-pubkey", help="Export the public key PEM.")
+    export_parser.add_argument("--key", required=True, help="Path to the Ed25519 private key PEM.")
+    export_parser.add_argument("--out", required=True, help="Output path for the public key PEM.")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "sign":
+        return _cmd_sign(args)
+    if args.command == "verify":
+        return _cmd_verify(args)
+    if args.command == "export-pubkey":
+        return _cmd_export_pubkey(args)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds local Ed25519 signing helpers for document hashes and index export envelopes.
- Adds a standalone index signing tool for signing, verifying, and exporting public keys.
- Documents provenance signing in CHANGELOG and ROADMAP.

## Safety and privacy

- Verification proves integrity against a public key; identity trust still requires callers to pin or verify the key fingerprint out of band.
- Generated private keys are created with mode 0600.
- No private deployment details, hostnames, or implementation notes are included.

## Tests

- PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/test_signer.py tests/test_index_sign.py tests/test_public_docs_hygiene.py -q
- python3 -m pytest -q
