### PR TITLE
Add PPTX ingest support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to alcove-search.
 
+## [Unreleased]
+
+- Add built-in PPTX text extraction and pipeline dispatch.
+
 ## [0.3.0] - 2026-03-07
 
 - Add theme toggle, fix WCAG AA contrast, update accessibility docs

--- a/alcove/ingest/extractors.py
+++ b/alcove/ingest/extractors.py
@@ -79,3 +79,22 @@ def extract_docx(path: Path) -> str:
 
     doc = docx.Document(str(path))
     return "\n".join(p.text for p in doc.paragraphs)
+
+
+def extract_pptx(path: Path) -> str:
+    try:
+        from pptx import Presentation
+    except ImportError as e:
+        raise ImportError("python-pptx is required for .pptx support: pip install python-pptx") from e
+
+    presentation = Presentation(str(path))
+    texts: List[str] = []
+    for slide in presentation.slides:
+        for shape in slide.shapes:
+            if not getattr(shape, "has_text_frame", False):
+                continue
+            for paragraph in shape.text_frame.paragraphs:
+                text = paragraph.text.strip()
+                if text:
+                    texts.append(text)
+    return "\n".join(texts)

--- a/alcove/ingest/pipeline.py
+++ b/alcove/ingest/pipeline.py
@@ -17,6 +17,7 @@ from .extractors import (
     extract_jsonl,
     extract_md,
     extract_pdf,
+    extract_pptx,
     extract_rst,
     extract_tsv,
     extract_txt,
@@ -37,6 +38,7 @@ _BUILTIN_EXTRACTORS = {
     ".json": extract_json,
     ".jsonl": extract_jsonl,
     ".docx": extract_docx,
+    ".pptx": extract_pptx,
 }
 
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,7 +10,7 @@ This is the foundation. Everything below builds on it.
 
 ## Near-term
 
-**More formats.** RTF, ODT, PPTX, XLSX. The [extractor plugin API](ARCHITECTURE.md#plugin-system) already supports this; the work is writing and testing each one.
+**More formats.** RTF, ODT, XLSX. PPTX is now supported by the built-in ingest pipeline. The [extractor plugin API](ARCHITECTURE.md#plugin-system) already supports additional formats; the work is writing and testing each one.
 
 **Semantic search as default.** The hash embedder exists for zero-download offline bootstrapping and for operators who do not want ML in the pipeline. Once the onboarding experience is smooth enough, sentence-transformers (or a lighter alternative) becomes the default install. The hash embedder stays available: not a stepping stone, but a permanent option for people who want deterministic, inspectable results.
 
@@ -48,7 +48,6 @@ Extractors receive a file path and return a list of text chunks. The entry point
 |-----------|---------|--------|
 | RTF | `striprtf` | `ep.name = "rtf"`, callable strips RTF markup → plain text, chunked by paragraph |
 | ODT / ODP / ODS | `odfpy` | `ep.name = "odt"` etc.; parse ODF XML, extract text nodes, chunk by heading or paragraph |
-| PPTX | `python-pptx` | `ep.name = "pptx"`; iterate slides, pull `shape.text_frame.text`, one chunk per slide |
 | XLSX | `openpyxl` | `ep.name = "xlsx"`; iterate sheets and rows, emit one chunk per sheet (column headers + row values as prose) |
 | HTML | `beautifulsoup4` | `ep.name = "html"`; strip tags, extract visible text, chunk by block element |
 | Audio transcription | `faster-whisper` | `ep.name = "mp3"` / `"wav"` / `"m4a"`; transcribe via local Whisper model, emit time-coded text chunks |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.3", "python-docx>=1.0", "httpx>=0.27", "defusedxml>=0.7", "requests>=2.28"]
+dev = ["pytest>=8.3", "python-docx>=1.0", "python-pptx>=1.0", "httpx>=0.27", "defusedxml>=0.7", "requests>=2.28"]
 docx = ["python-docx>=1.0"]
+pptx = ["python-pptx>=1.0"]
 semantic = ["sentence-transformers>=3.0"]
 epub = ["ebooklib>=0.18,<1.0"]
 zvec = ["zvec>=0.1"]

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -131,8 +131,8 @@ def test_extract_pptx_raises_helpful_import_error(tmp_path, monkeypatch):
 
 def test_pipeline_dispatch_includes_html(tmp_path):
     """Pipeline routes .html files through the extractor without error."""
-    import json
     from alcove.ingest.pipeline import run
+
     f = tmp_path / "doc.html"
     f.write_text("<p>Semantic search content</p>")
     out = tmp_path / "chunks.jsonl"
@@ -144,8 +144,8 @@ def test_pipeline_dispatch_includes_html(tmp_path):
 
 def test_pipeline_dispatch_includes_md(tmp_path):
     """Pipeline routes .md files through the extractor without error."""
-    import json
     from alcove.ingest.pipeline import run
+
     f = tmp_path / "notes.md"
     f.write_text("# Notes\n\nLocal retrieval is fast.")
     out = tmp_path / "chunks.jsonl"
@@ -157,7 +157,6 @@ def test_pipeline_dispatch_includes_md(tmp_path):
 
 def test_pipeline_dispatch_includes_pptx(tmp_path):
     """Pipeline routes .pptx files through the extractor without error."""
-    import json
     from alcove.ingest.pipeline import run
 
     f = tmp_path / "deck.pptx"

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -87,6 +87,48 @@ def test_extract_docx_returns_paragraph_text(tmp_path):
     assert "Alcove document extraction test." in result
 
 
+def _write_sample_pptx(path: Path, lines: list[str]) -> None:
+    pptx = pytest.importorskip("pptx", reason="python-pptx not installed")
+    from pptx.util import Inches
+
+    presentation = pptx.Presentation()
+    slide = presentation.slides.add_slide(presentation.slide_layouts[5])
+    textbox = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(8), Inches(2))
+    text_frame = textbox.text_frame
+    for index, line in enumerate(lines):
+        paragraph = text_frame.paragraphs[0] if index == 0 else text_frame.add_paragraph()
+        paragraph.text = line
+    presentation.save(str(path))
+
+
+def test_extract_pptx_returns_slide_text(tmp_path):
+    from alcove.ingest.extractors import extract_pptx
+
+    f = tmp_path / "sample.pptx"
+    _write_sample_pptx(f, ["Alcove slide title", "Semantic search for local docs"])
+    result = extract_pptx(f)
+    assert "Alcove slide title" in result
+    assert "Semantic search for local docs" in result
+
+
+def test_extract_pptx_raises_helpful_import_error(tmp_path, monkeypatch):
+    from alcove.ingest import extractors
+
+    f = tmp_path / "sample.pptx"
+    f.write_bytes(b"not-a-real-pptx")
+
+    real_import = __import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name == "pptx":
+            raise ImportError("missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", blocked_import)
+    with pytest.raises(ImportError, match="python-pptx is required"):
+        extractors.extract_pptx(f)
+
+
 def test_pipeline_dispatch_includes_html(tmp_path):
     """Pipeline routes .html files through the extractor without error."""
     import json
@@ -111,6 +153,20 @@ def test_pipeline_dispatch_includes_md(tmp_path):
     assert n >= 1
     records = [json.loads(line) for line in out.read_text().splitlines()]
     assert any("Local retrieval is fast." in r["chunk"] for r in records)
+
+
+def test_pipeline_dispatch_includes_pptx(tmp_path):
+    """Pipeline routes .pptx files through the extractor without error."""
+    import json
+    from alcove.ingest.pipeline import run
+
+    f = tmp_path / "deck.pptx"
+    _write_sample_pptx(f, ["Deck heading", "Deck body text"])
+    out = tmp_path / "chunks.jsonl"
+    n = run(raw_dir=str(tmp_path), out_file=str(out))
+    assert n >= 1
+    records = [json.loads(line) for line in out.read_text().splitlines()]
+    assert any("Deck heading" in r["chunk"] for r in records)
 
 
 def test_extract_tsv_tab_separated(tmp_path):


### PR DESCRIPTION
## Summary

- Adds built-in PPTX text extraction through `python-pptx`.
- Routes `.pptx` files through the ingest pipeline.
- Updates CHANGELOG and ROADMAP so the public docs reflect the new format support.

## Safety and privacy

- Keeps PPTX support local-only and optional through the `pptx` extra.
- Adds no private deployment details, hostnames, or implementation notes.

## Tests

- python3 -m pytest tests/test_extractors.py tests/test_pipeline_empty.py tests/test_public_docs_hygiene.py -q
- python3 -m pytest -q
