### PR TITLE
Add Ollama embedder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to alcove-search.
 
+## [Unreleased]
+
+- Add `EMBEDDER=ollama` for local Ollama embedding models.
+
 ## [0.3.0] - 2026-03-07
 
 - Add theme toggle, fix WCAG AA contrast, update accessibility docs

--- a/alcove/index/embedder.py
+++ b/alcove/index/embedder.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
+import urllib.error
+import urllib.request
 from typing import List
 
 
@@ -34,17 +37,95 @@ class SentenceTransformerEmbedder:
         return [vec.tolist() for vec in embeddings]
 
 
+class OllamaEmbedder:
+    """Semantic embedder backed by a local Ollama model."""
+
+    def __init__(
+        self,
+        model_name: str | None = None,
+        base_url: str | None = None,
+        timeout: float | None = None,
+        dim: int | None = None,
+    ):
+        self.model_name = model_name or os.getenv("OLLAMA_MODEL", "nomic-embed-text")
+        self.base_url = (
+            base_url or os.getenv("OLLAMA_BASE_URL", "http://127.0.0.1:11434")
+        ).rstrip("/")
+        self.timeout = float(timeout or os.getenv("OLLAMA_TIMEOUT", "60"))
+        self.dim = int(dim or os.getenv("OLLAMA_DIM", "768"))
+
+    def embed(self, texts: List[str]) -> List[List[float]]:
+        if not texts:
+            return []
+
+        try:
+            payload = self._post("/api/embed", {"model": self.model_name, "input": texts})
+            embeddings = payload.get("embeddings")
+            if not isinstance(embeddings, list):
+                raise RuntimeError("Ollama /api/embed response did not include embeddings.")
+            return embeddings
+        except urllib.error.HTTPError as exc:
+            if exc.code not in {400, 404}:
+                raise RuntimeError(self._format_http_error(exc)) from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(self._format_url_error(exc)) from exc
+
+        vectors: List[List[float]] = []
+        for text in texts:
+            try:
+                payload = self._post(
+                    "/api/embeddings",
+                    {"model": self.model_name, "prompt": text},
+                )
+            except urllib.error.HTTPError as exc:
+                raise RuntimeError(self._format_http_error(exc)) from exc
+            except urllib.error.URLError as exc:
+                raise RuntimeError(self._format_url_error(exc)) from exc
+
+            embedding = payload.get("embedding")
+            if not isinstance(embedding, list):
+                raise RuntimeError("Ollama /api/embeddings response did not include an embedding.")
+            vectors.append(embedding)
+        return vectors
+
+    def _post(self, path: str, payload: dict) -> dict:
+        body = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            f"{self.base_url}{path}",
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=self.timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    def _format_http_error(self, exc: urllib.error.HTTPError) -> str:
+        return (
+            f"Ollama request failed with HTTP {exc.code} against {self.base_url} "
+            f"while using model {self.model_name!r}."
+        )
+
+    def _format_url_error(self, exc: urllib.error.URLError) -> str:
+        return (
+            f"Could not reach Ollama at {self.base_url} while using model "
+            f"{self.model_name!r}: {exc.reason}"
+        )
+
+
 def get_collection_name(base_name: str) -> str:
     """Append embedder-specific suffix to collection name."""
     embedder = os.getenv("EMBEDDER", "hash")
     if embedder == "sentence-transformers":
         return f"{base_name}_st"
+    if embedder == "ollama":
+        return f"{base_name}_ollama"
     return base_name
 
 
 _BUILTIN_EMBEDDERS = {
     "hash": HashEmbedder,
     "sentence-transformers": SentenceTransformerEmbedder,
+    "ollama": OllamaEmbedder,
 }
 
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,6 +40,7 @@ data/raw/*  →  data/processed/chunks.jsonl  →  vector store  →  query resp
 |------|-----------|-------------|
 | Hash (default) | `EMBEDDER=hash` | Deterministic SHA-256 hash. Offline, zero download. Useful for smoke tests and CI. |
 | Sentence Transformers | `EMBEDDER=sentence-transformers` | Real semantic search via `all-MiniLM-L6-v2` (~80 MB model, downloaded on first use) |
+| Ollama | `EMBEDDER=ollama` | Real semantic search via an operator-managed local Ollama server |
 
 Set the embedder with the `EMBEDDER` environment variable. See [OPERATIONS.md](OPERATIONS.md#environment-variables) for how to configure it. Custom embedders can be installed as plugins.
 
@@ -73,7 +74,7 @@ Plugins are merged with built-ins at startup. When a plugin and a built-in share
 
 ## Boundary
 
-The operator owns the host and the storage. Alcove makes no outbound network calls by default; the one exception is `sentence-transformers`, which downloads a model on first use and then runs locally. Telemetry is disabled, including ChromaDB's upstream telemetry. See [SECURITY.md](SECURITY.md#security-model) for the full security model.
+The operator owns the host and the storage. Alcove makes no outbound network calls by default; the one exception is `sentence-transformers`, which downloads a model on first use and then runs locally. `EMBEDDER=ollama` sends chunk text only to the Ollama base URL the operator configures, defaulting to the local loopback interface. Telemetry is disabled, including ChromaDB's upstream telemetry. See [SECURITY.md](SECURITY.md#security-model) for the full security model.
 
 This boundary is structural, not configurable. There is no flag to turn it off.
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -22,6 +22,18 @@ EMBEDDER=sentence-transformers alcove serve
 
 This downloads `all-MiniLM-L6-v2` (~80 MB) on first use. See [Seed Corpus](SEED_CORPUS.md) for what `seed-demo` includes. The model is cached locally; subsequent runs are offline.
 
+## Local Ollama embeddings
+
+If you already run Ollama locally, Alcove can use an embedding model served from that local process:
+
+```bash
+ollama pull nomic-embed-text
+EMBEDDER=ollama OLLAMA_MODEL=nomic-embed-text alcove seed-demo
+EMBEDDER=ollama OLLAMA_MODEL=nomic-embed-text alcove serve
+```
+
+By default Alcove connects to `http://127.0.0.1:11434`. Set `OLLAMA_BASE_URL` to use another operator-managed local endpoint. When using the zvec backend with a non-default embedding model, set `OLLAMA_DIM` to that model's vector dimension before creating the index.
+
 ## Custom documents
 
 ```bash
@@ -50,7 +62,11 @@ Bind to a non-localhost address only after reviewing [Security: Operator Respons
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `EMBEDDER` | `hash` | Embedder to use (`hash` or `sentence-transformers`) |
+| `EMBEDDER` | `hash` | Embedder to use (`hash`, `sentence-transformers`, or `ollama`) |
+| `OLLAMA_BASE_URL` | `http://127.0.0.1:11434` | Local Ollama base URL when `EMBEDDER=ollama` |
+| `OLLAMA_MODEL` | `nomic-embed-text` | Ollama embedding model when `EMBEDDER=ollama` |
+| `OLLAMA_TIMEOUT` | `60` | Ollama request timeout in seconds |
+| `OLLAMA_DIM` | `768` | Ollama embedding dimension for backends that need it at initialization |
 | `VECTOR_BACKEND` | `chromadb` | Vector store (`chromadb` or `zvec`) |
 | `CHROMA_PATH` | `./data/chroma` | ChromaDB persistence directory |
 | `CHROMA_COLLECTION` | `alcove_docs` | Collection name |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Current release (v0.3.0)
 
-Alcove ships a working three-stage pipeline: ingest, index, query. Eleven document formats. Two embedders (hash for offline determinism, sentence-transformers for real semantic search). Two vector backends (ChromaDB, zvec). A plugin system.
+Alcove ships a working three-stage pipeline: ingest, index, query. Eleven document formats. Three embedders (hash for offline determinism, sentence-transformers for local semantic search, Ollama for operator-managed local models). Two vector backends (ChromaDB, zvec). A plugin system.
 
 A web UI with upload and search. CI across Python 3.10, 3.11, 3.12. Docker deployment. Apache 2.0.
 
@@ -13,6 +13,8 @@ This is the foundation. Everything below builds on it.
 **More formats.** RTF, ODT, PPTX, XLSX. The [extractor plugin API](ARCHITECTURE.md#plugin-system) already supports this; the work is writing and testing each one.
 
 **Semantic search as default.** The hash embedder exists for zero-download offline bootstrapping and for operators who do not want ML in the pipeline. Once the onboarding experience is smooth enough, sentence-transformers (or a lighter alternative) becomes the default install. The hash embedder stays available: not a stepping stone, but a permanent option for people who want deterministic, inspectable results.
+
+**Local model hooks.** `EMBEDDER=ollama` now lets operators point Alcove at a local Ollama server for embeddings. Near-term work is documentation polish and model-specific guidance, not hosted inference or generated answers.
 
 **Browse mode.** Alcove should be navigable, not just searchable. Directory-aware corpus browsing in the web UI: see what you have, not just what matches a query. Search and browse are complementary interfaces to the same index.
 
@@ -62,7 +64,7 @@ Embedders receive a list of strings and return a list of float vectors. They reg
 | Candidate | Library | Wiring |
 |-----------|---------|--------|
 | OpenAI | `openai` | Calls `client.embeddings.create(model="text-embedding-3-small", input=texts)`; requires `OPENAI_API_KEY`. Breaks local-only boundary — document this clearly. |
-| Ollama | `ollama` | Calls local `ollama.embeddings(model=..., prompt=text)` per chunk; model configured via env var. Zero-download after first pull. |
+| Ollama | built-in | Calls a local Ollama server via `EMBEDDER=ollama`; model configured via env vars. Zero-download after first pull. |
 | MLX (Apple Silicon) | `mlx-lm` | Runs embedding model via MLX on M-series GPU; fastest local option for Apple hardware. |
 | Cohere | `cohere` | Calls `co.embed(texts=..., model=...)` via Cohere API; requires API key. Cloud boundary applies. |
 

--- a/tests/test_embedder_factory.py
+++ b/tests/test_embedder_factory.py
@@ -1,7 +1,7 @@
 import os
 import pytest
 
-from alcove.index.embedder import HashEmbedder
+from alcove.index.embedder import HashEmbedder, OllamaEmbedder
 
 
 def test_get_embedder_default_is_hash():
@@ -21,6 +21,16 @@ def test_get_embedder_explicit_hash():
         assert isinstance(emb, HashEmbedder)
     finally:
         os.environ.pop("EMBEDDER", None)
+
+
+def test_get_embedder_explicit_ollama(monkeypatch):
+    from alcove.index.embedder import get_embedder
+
+    monkeypatch.setenv("EMBEDDER", "ollama")
+
+    emb = get_embedder()
+
+    assert isinstance(emb, OllamaEmbedder)
 
 
 def test_get_embedder_unknown_raises():
@@ -62,3 +72,13 @@ def test_get_collection_name_st_appends_suffix():
         assert name == "alcove_docs_st"
     finally:
         os.environ.pop("EMBEDDER", None)
+
+
+def test_get_collection_name_ollama_appends_suffix(monkeypatch):
+    from alcove.index.embedder import get_collection_name
+
+    monkeypatch.setenv("EMBEDDER", "ollama")
+
+    name = get_collection_name("alcove_docs")
+
+    assert name == "alcove_docs_ollama"

--- a/tests/test_embedder_ollama.py
+++ b/tests/test_embedder_ollama.py
@@ -106,3 +106,69 @@ def test_ollama_embedder_reports_unreachable_server(monkeypatch):
 
     with pytest.raises(RuntimeError, match="Could not reach Ollama"):
         embedder.embed(["hello"])
+
+
+def test_ollama_embedder_rejects_batch_response_without_embeddings(monkeypatch):
+    def fake_urlopen(req, timeout):
+        return _FakeResponse({"ok": True})
+
+    monkeypatch.setattr("alcove.index.embedder.urllib.request.urlopen", fake_urlopen)
+
+    embedder = OllamaEmbedder(base_url="http://127.0.0.1:11434")
+
+    with pytest.raises(RuntimeError, match="/api/embed response did not include embeddings"):
+        embedder.embed(["hello"])
+
+
+def test_ollama_embedder_reports_batch_http_errors(monkeypatch):
+    def fake_urlopen(req, timeout):
+        raise HTTPError(req.full_url, 500, "server error", hdrs=None, fp=BytesIO(b""))
+
+    monkeypatch.setattr("alcove.index.embedder.urllib.request.urlopen", fake_urlopen)
+
+    embedder = OllamaEmbedder(base_url="http://127.0.0.1:11434")
+
+    with pytest.raises(RuntimeError, match="HTTP 500"):
+        embedder.embed(["hello"])
+
+
+def test_ollama_embedder_reports_legacy_http_errors(monkeypatch):
+    def fake_urlopen(req, timeout):
+        if req.full_url.endswith("/api/embed"):
+            raise HTTPError(req.full_url, 404, "not found", hdrs=None, fp=BytesIO(b""))
+        raise HTTPError(req.full_url, 500, "server error", hdrs=None, fp=BytesIO(b""))
+
+    monkeypatch.setattr("alcove.index.embedder.urllib.request.urlopen", fake_urlopen)
+
+    embedder = OllamaEmbedder(base_url="http://127.0.0.1:11434")
+
+    with pytest.raises(RuntimeError, match="HTTP 500"):
+        embedder.embed(["hello"])
+
+
+def test_ollama_embedder_reports_legacy_url_errors(monkeypatch):
+    def fake_urlopen(req, timeout):
+        if req.full_url.endswith("/api/embed"):
+            raise HTTPError(req.full_url, 404, "not found", hdrs=None, fp=BytesIO(b""))
+        raise URLError("connection refused")
+
+    monkeypatch.setattr("alcove.index.embedder.urllib.request.urlopen", fake_urlopen)
+
+    embedder = OllamaEmbedder(base_url="http://127.0.0.1:11434")
+
+    with pytest.raises(RuntimeError, match="Could not reach Ollama"):
+        embedder.embed(["hello"])
+
+
+def test_ollama_embedder_rejects_legacy_response_without_embedding(monkeypatch):
+    def fake_urlopen(req, timeout):
+        if req.full_url.endswith("/api/embed"):
+            raise HTTPError(req.full_url, 404, "not found", hdrs=None, fp=BytesIO(b""))
+        return _FakeResponse({"ok": True})
+
+    monkeypatch.setattr("alcove.index.embedder.urllib.request.urlopen", fake_urlopen)
+
+    embedder = OllamaEmbedder(base_url="http://127.0.0.1:11434")
+
+    with pytest.raises(RuntimeError, match="/api/embeddings response did not include an embedding"):
+        embedder.embed(["hello"])

--- a/tests/test_embedder_ollama.py
+++ b/tests/test_embedder_ollama.py
@@ -1,0 +1,108 @@
+import json
+from io import BytesIO
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from alcove.index.embedder import OllamaEmbedder
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._buffer = BytesIO(json.dumps(payload).encode("utf-8"))
+
+    def read(self, *args, **kwargs):
+        return self._buffer.read(*args, **kwargs)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_ollama_embedder_uses_batch_endpoint(monkeypatch):
+    calls = []
+
+    def fake_urlopen(req, timeout):
+        calls.append(
+            {
+                "url": req.full_url,
+                "payload": json.loads(req.data.decode("utf-8")),
+                "timeout": timeout,
+            }
+        )
+        return _FakeResponse({"embeddings": [[0.1, 0.2], [0.3, 0.4]]})
+
+    monkeypatch.setattr("alcove.index.embedder.urllib.request.urlopen", fake_urlopen)
+
+    embedder = OllamaEmbedder(
+        base_url="http://127.0.0.1:11434",
+        model_name="nomic-embed-text",
+        timeout=12,
+    )
+
+    assert embedder.embed(["hello", "world"]) == [[0.1, 0.2], [0.3, 0.4]]
+    assert calls == [
+        {
+            "url": "http://127.0.0.1:11434/api/embed",
+            "payload": {"model": "nomic-embed-text", "input": ["hello", "world"]},
+            "timeout": 12,
+        }
+    ]
+
+
+def test_ollama_embedder_falls_back_to_legacy_endpoint(monkeypatch):
+    calls = []
+
+    def fake_urlopen(req, timeout):
+        calls.append(req.full_url)
+        if req.full_url.endswith("/api/embed"):
+            raise HTTPError(
+                req.full_url,
+                404,
+                "not found",
+                hdrs=None,
+                fp=BytesIO(b'{"error":"not found"}'),
+            )
+
+        payload = json.loads(req.data.decode("utf-8"))
+        return _FakeResponse({"embedding": [len(payload["prompt"]), 1.0]})
+
+    monkeypatch.setattr("alcove.index.embedder.urllib.request.urlopen", fake_urlopen)
+
+    embedder = OllamaEmbedder(
+        base_url="http://127.0.0.1:11434",
+        model_name="nomic-embed-text",
+        timeout=5,
+    )
+
+    assert embedder.embed(["hi", "there"]) == [[2, 1.0], [5, 1.0]]
+    assert calls == [
+        "http://127.0.0.1:11434/api/embed",
+        "http://127.0.0.1:11434/api/embeddings",
+        "http://127.0.0.1:11434/api/embeddings",
+    ]
+
+
+def test_ollama_embedder_empty_input_does_not_call_api(monkeypatch):
+    def fake_urlopen(req, timeout):
+        raise AssertionError("urlopen should not be called for empty input")
+
+    monkeypatch.setattr("alcove.index.embedder.urllib.request.urlopen", fake_urlopen)
+
+    embedder = OllamaEmbedder()
+
+    assert embedder.embed([]) == []
+
+
+def test_ollama_embedder_reports_unreachable_server(monkeypatch):
+    def fake_urlopen(req, timeout):
+        raise URLError("connection refused")
+
+    monkeypatch.setattr("alcove.index.embedder.urllib.request.urlopen", fake_urlopen)
+
+    embedder = OllamaEmbedder(base_url="http://127.0.0.1:11434")
+
+    with pytest.raises(RuntimeError, match="Could not reach Ollama"):
+        embedder.embed(["hello"])


### PR DESCRIPTION
## Summary

- Adds `EMBEDDER=ollama` for operator-managed local Ollama embedding models.
- Supports Ollama `/api/embed` with fallback to legacy `/api/embeddings`.
- Documents local Ollama setup and updates CHANGELOG/ROADMAP/architecture docs.

## Safety and privacy

- Defaults to loopback `http://127.0.0.1:11434`.
- Sends chunk text only to the operator-configured Ollama base URL.
- Adds no private deployment details, hostnames, or implementation notes.

## Tests

- python3 -m pytest tests/test_embedder_factory.py tests/test_embedder_ollama.py -q
- python3 -m pytest tests/test_smoke.py tests/test_backend.py tests/test_embedder_factory.py tests/test_embedder_ollama.py -q
- python3 -m compileall alcove/index/embedder.py
- python3 -m pytest -q
