### PR TITLE
Add language-aware retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to alcove-search.
 
+## [Unreleased]
+
+- Add local language detection metadata during indexing and language-aware query filters.
+
 ## [0.3.0] - 2026-03-07
 
 - Add theme toggle, fix WCAG AA contrast, update accessibility docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to alcove-search.
 
 ## [Unreleased]
 
-- Add local language detection metadata during indexing and language-aware query filters.
+- Add configurable language metadata during indexing and language-aware query filters.
 - Add `EMBEDDER=ollama` for local Ollama embedding models.
 - Add built-in PPTX text extraction and pipeline dispatch.
 - Add local Ed25519 signing helpers and a standalone index signing tool for provenance checks.

--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ This pulls in sentence-transformers for real vector similarity (~80 MB model dow
 | Extra | Install command | What it adds |
 |-------|----------------|--------------|
 | Semantic search | `pip install alcove-search[semantic]` | Real vector similarity via sentence-transformers |
+| Language detection | `pip install alcove-search[language]` | Optional langdetect and Hugging Face language metadata providers |
 | EPUB support | `pip install alcove-search[epub]` | `.epub` file ingestion |
 | DOCX support | `pip install alcove-search[docx]` | `.docx` file ingestion |
-| Everything | `pip install alcove-search[semantic,epub,docx]` | All of the above |
+| Everything | `pip install alcove-search[semantic,language,epub,docx]` | All of the above |
 
 </details>
 

--- a/alcove/config.py
+++ b/alcove/config.py
@@ -48,6 +48,7 @@ class Language:
     confidence_threshold: float = 0.0
     ollama_base_url: str = "http://127.0.0.1:11434"
     timeout: float = 30.0
+    max_chars: int = 4000
 
 
 @dataclass(frozen=True, slots=True)
@@ -150,6 +151,12 @@ def load_config() -> RuntimeConfig:
                 config_value=values.get("language.timeout"),
                 default=30.0,
                 minimum=0.1,
+            ),
+            max_chars=_resolve_int(
+                env_name="ALCOVE_LANGUAGE_MAX_CHARS",
+                config_value=values.get("language.max_chars"),
+                default=4000,
+                minimum=1,
             ),
         ),
         recent_activity_limit=_resolve_int(

--- a/alcove/config.py
+++ b/alcove/config.py
@@ -353,15 +353,17 @@ def _resolve_float(
     minimum: float,
     maximum: float | None = None,
 ) -> float:
+    def _clamp(value: float) -> float:
+        value = max(minimum, value)
+        return min(maximum, value) if maximum is not None else value
+
     env_value = os.getenv(env_name)
     if env_value is not None:
         parsed = _coerce_float(env_value)
-        value = default if parsed is None else max(minimum, parsed)
-        return min(maximum, value) if maximum is not None else value
+        return _clamp(default if parsed is None else parsed)
 
     parsed = _coerce_float(config_value)
-    value = default if parsed is None else max(minimum, parsed)
-    return min(maximum, value) if maximum is not None else value
+    return _clamp(default if parsed is None else parsed)
 
 
 def _coerce_bool(value: object) -> bool | None:

--- a/alcove/config.py
+++ b/alcove/config.py
@@ -40,9 +40,21 @@ class Deployment:
 
 
 @dataclass(frozen=True, slots=True)
+class Language:
+    """Language metadata detection settings."""
+
+    provider: str = "heuristic"
+    model: str | None = None
+    confidence_threshold: float = 0.0
+    ollama_base_url: str = "http://127.0.0.1:11434"
+    timeout: float = 30.0
+
+
+@dataclass(frozen=True, slots=True)
 class RuntimeConfig:
     features: Features = field(default_factory=Features)
     deployment: Deployment = field(default_factory=Deployment)
+    language: Language = field(default_factory=Language)
     recent_activity_limit: int = 5
     excerpt_chars: int | None = None
     private_mode: bool = True
@@ -109,6 +121,35 @@ def load_config() -> RuntimeConfig:
                 env_name="ALCOVE_INSTANCE_NAME",
                 config_value=values.get("deployment.instance_name"),
                 default="Alcove",
+            ),
+        ),
+        language=Language(
+            provider=_resolve_str(
+                env_name="ALCOVE_LANGUAGE_PROVIDER",
+                config_value=values.get("language.provider"),
+                default="heuristic",
+            ),
+            model=_resolve_optional_str(
+                env_name="ALCOVE_LANGUAGE_MODEL",
+                config_value=values.get("language.model"),
+            ),
+            confidence_threshold=_resolve_float(
+                env_name="ALCOVE_LANGUAGE_CONFIDENCE_THRESHOLD",
+                config_value=values.get("language.confidence_threshold"),
+                default=0.0,
+                minimum=0.0,
+                maximum=1.0,
+            ),
+            ollama_base_url=_resolve_str(
+                env_name="ALCOVE_LANGUAGE_OLLAMA_BASE_URL",
+                config_value=values.get("language.ollama_base_url"),
+                default=os.getenv("OLLAMA_BASE_URL", "http://127.0.0.1:11434"),
+            ),
+            timeout=_resolve_float(
+                env_name="ALCOVE_LANGUAGE_TIMEOUT",
+                config_value=values.get("language.timeout"),
+                default=30.0,
+                minimum=0.1,
             ),
         ),
         recent_activity_limit=_resolve_int(
@@ -198,6 +239,11 @@ def _load_json_values(path: Path) -> dict[str, object]:
         for key, value in deployment.items():
             out[f"deployment.{key}"] = value
 
+    language = data.get("language")
+    if isinstance(language, dict):
+        for key, value in language.items():
+            out[f"language.{key}"] = value
+
     if "excerpt_chars" in data:
         out["excerpt_chars"] = data["excerpt_chars"]
     if "private_mode" in data:
@@ -266,6 +312,19 @@ def _resolve_str(
     return default
 
 
+def _resolve_optional_str(*, env_name: str, config_value: object) -> str | None:
+    env_value = os.getenv(env_name)
+    if env_value is not None:
+        value = env_value.strip()
+        return value or None
+
+    if isinstance(config_value, str):
+        value = config_value.strip()
+        return value or None
+
+    return None
+
+
 def _resolve_int(*, env_name: str, config_value: object, default: int, minimum: int) -> int:
     env_value = os.getenv(env_name)
     if env_value is not None:
@@ -286,6 +345,25 @@ def _resolve_optional_int(*, env_name: str, config_value: object, minimum: int) 
     return None if parsed is None else max(minimum, parsed)
 
 
+def _resolve_float(
+    *,
+    env_name: str,
+    config_value: object,
+    default: float,
+    minimum: float,
+    maximum: float | None = None,
+) -> float:
+    env_value = os.getenv(env_name)
+    if env_value is not None:
+        parsed = _coerce_float(env_value)
+        value = default if parsed is None else max(minimum, parsed)
+        return min(maximum, value) if maximum is not None else value
+
+    parsed = _coerce_float(config_value)
+    value = default if parsed is None else max(minimum, parsed)
+    return min(maximum, value) if maximum is not None else value
+
+
 def _coerce_bool(value: object) -> bool | None:
     if isinstance(value, bool):
         return value
@@ -297,6 +375,19 @@ def _coerce_bool(value: object) -> bool | None:
             return True
         if lowered in {"0", "false", "no", "off"}:
             return False
+    return None
+
+
+def _coerce_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return float(value)
+    if isinstance(value, (float, int)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value.strip())
+        except ValueError:
+            return None
     return None
 
 

--- a/alcove/index/backend.py
+++ b/alcove/index/backend.py
@@ -9,6 +9,22 @@ from chromadb.config import Settings
 from .embedder import get_collection_name
 
 
+def _query_where(
+    collections: Optional[List[str]] = None,
+    language_filter: Optional[str] = None,
+) -> Optional[dict]:
+    clauses = []
+    if collections:
+        clauses.append({"collection": {"$in": collections}})
+    if language_filter:
+        clauses.append({"language": language_filter.lower()})
+    if not clauses:
+        return None
+    if len(clauses) == 1:
+        return clauses[0]
+    return {"$and": clauses}
+
+
 class MultiChromaBackend:
     """Vector backend that fans out across ALL ChromaDB collections in CHROMA_PATH.
 
@@ -84,7 +100,13 @@ class MultiChromaBackend:
                 embeddings=group["embeddings"],
             )
 
-    def query(self, embedding, k=3, collections: Optional[List[str]] = None):
+    def query(
+        self,
+        embedding,
+        k=3,
+        collections: Optional[List[str]] = None,
+        language_filter: Optional[str] = None,
+    ):
         """Fan out query to all (or filtered) collections and merge by distance."""
         target_cols = self._get_filtered_collections(collections)
         if not target_cols:
@@ -101,11 +123,15 @@ class MultiChromaBackend:
                 if col_count == 0:
                     continue
                 n = min(k, col_count)
-                result = col.query(
-                    query_embeddings=[embedding],
-                    n_results=n,
-                    include=["documents", "distances", "metadatas"],
-                )
+                kwargs = {
+                    "query_embeddings": [embedding],
+                    "n_results": n,
+                    "include": ["documents", "distances", "metadatas"],
+                }
+                where = _query_where(language_filter=language_filter)
+                if where:
+                    kwargs["where"] = where
+                result = col.query(**kwargs)
                 ids = result.get("ids", [[]])[0]
                 docs = result.get("documents", [[]])[0]
                 dists = result.get("distances", [[]])[0]
@@ -204,7 +230,13 @@ class MultiRootBackend:
     def add(self, ids, embeddings, documents, metadatas):  # pragma: no cover
         raise NotImplementedError("MultiRootBackend is read-only; ingest each collection separately.")
 
-    def query(self, embedding, k=3, collections: Optional[List[str]] = None):
+    def query(
+        self,
+        embedding,
+        k=3,
+        collections: Optional[List[str]] = None,
+        language_filter: Optional[str] = None,
+    ):
         """Fan out query across all (or filtered) roots and merge by distance."""
         targets = self._cols
         if collections:
@@ -222,11 +254,15 @@ class MultiRootBackend:
                 if col_count == 0:
                     continue
                 n = min(k, col_count)
-                result = col.query(
-                    query_embeddings=[embedding],
-                    n_results=n,
-                    include=["documents", "distances", "metadatas"],
-                )
+                kwargs = {
+                    "query_embeddings": [embedding],
+                    "n_results": n,
+                    "include": ["documents", "distances", "metadatas"],
+                }
+                where = _query_where(language_filter=language_filter)
+                if where:
+                    kwargs["where"] = where
+                result = col.query(**kwargs)
                 ids = result.get("ids", [[]])[0]
                 docs = result.get("documents", [[]])[0]
                 dists = result.get("distances", [[]])[0]
@@ -285,10 +321,17 @@ class ChromaBackend:
             ids=ids, documents=documents, metadatas=metadatas, embeddings=embeddings,
         )
 
-    def query(self, embedding, k=3, collections: Optional[List[str]] = None):
+    def query(
+        self,
+        embedding,
+        k=3,
+        collections: Optional[List[str]] = None,
+        language_filter: Optional[str] = None,
+    ):
         kwargs: dict = {"query_embeddings": [embedding], "n_results": k}
-        if collections:
-            kwargs["where"] = {"collection": {"$in": collections}}
+        where = _query_where(collections=collections, language_filter=language_filter)
+        if where:
+            kwargs["where"] = where
         return self._collection.query(**kwargs)
 
     def count(self):
@@ -327,6 +370,7 @@ class ZvecBackend:
                     _zvec.FieldSchema("document", _zvec.DataType.STRING),
                     _zvec.FieldSchema("source", _zvec.DataType.STRING),
                     _zvec.FieldSchema("collection", _zvec.DataType.STRING),
+                    _zvec.FieldSchema("language", _zvec.DataType.STRING),
                 ],
                 vectors=_zvec.VectorSchema(
                     "embedding", _zvec.DataType.VECTOR_FP32, dimension=self._dim,
@@ -349,32 +393,66 @@ class ZvecBackend:
                         "document": documents[i],
                         "source": metadatas[i].get("source", ""),
                         "collection": coll,
+                        "language": (metadatas[i].get("language") or "unknown").lower(),
                     },
                 )
             )
         self._collection.upsert(docs)
         self._collection.flush()
 
-    def query(self, embedding, k=3, collections: Optional[List[str]] = None):
+    def query(
+        self,
+        embedding,
+        k=3,
+        collections: Optional[List[str]] = None,
+        language_filter: Optional[str] = None,
+    ):
         _zvec = self._zvec
-        results = self._collection.query(
-            vectors=_zvec.VectorQuery("embedding", vector=embedding),
-            topk=k,
-            output_fields=["document", "source", "collection"],
-        )
+        topk = max(k * 5, k) if collections or language_filter else k
+        try:
+            results = self._collection.query(
+                vectors=_zvec.VectorQuery("embedding", vector=embedding),
+                topk=topk,
+                output_fields=["document", "source", "collection", "language"],
+            )
+            has_language_field = True
+        except Exception:
+            results = self._collection.query(
+                vectors=_zvec.VectorQuery("embedding", vector=embedding),
+                topk=topk,
+                output_fields=["document", "source", "collection"],
+            )
+            has_language_field = False
         ids = []
         documents = []
         distances = []
+        metadatas = []
         for doc in results:
             # Filter by collection in Python if requested.
             if collections:
                 doc_coll = doc.field("collection") or "default"
                 if doc_coll not in collections:
                     continue
+            language = (doc.field("language") if has_language_field else "unknown") or "unknown"
+            language = language.lower()
+            if language_filter and language != language_filter.lower():
+                continue
             ids.append(doc.id)
             documents.append(doc.field("document"))
             distances.append(-doc.score)  # negate: ChromaDB uses lower=better
-        return {"ids": [ids], "documents": [documents], "distances": [distances]}
+            metadatas.append({
+                "source": doc.field("source"),
+                "collection": doc.field("collection") or "default",
+                "language": language,
+            })
+            if len(ids) >= k:
+                break
+        return {
+            "ids": [ids],
+            "documents": [documents],
+            "distances": [distances],
+            "metadatas": [metadatas],
+        }
 
     def count(self):
         return self._collection.stats.doc_count

--- a/alcove/index/keyword.py
+++ b/alcove/index/keyword.py
@@ -6,6 +6,8 @@ import os
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from .language import detect_language
+
 
 class KeywordIndex:
     """BM25-based keyword search over a chunks.jsonl file.
@@ -42,6 +44,8 @@ class KeywordIndex:
                         "id": rec.get("id", ""),
                         "text": text,
                         "source": rec.get("source", ""),
+                        "collection": rec.get("collection", "default"),
+                        "language": (rec.get("language") or detect_language(text)).lower(),
                     })
                     tokenized.append(text.lower().split())
 
@@ -50,7 +54,13 @@ class KeywordIndex:
         else:
             self._bm25 = None
 
-    def search(self, query: str, k: int = 3) -> dict:
+    def search(
+        self,
+        query: str,
+        k: int = 3,
+        language_filter: Optional[str] = None,
+        collections: Optional[List[str]] = None,
+    ) -> dict:
         """Search the keyword index for the given query.
 
         Returns results in ChromaDB-compatible format:
@@ -83,18 +93,31 @@ class KeywordIndex:
                 norm = 0.0
             scored.append((idx, norm))
 
-        # Sort by normalized score descending, take top-k
+        # Sort by normalized score descending. Apply metadata filters while
+        # collecting so matching documents beyond the first k can still surface.
         scored.sort(key=lambda x: x[1], reverse=True)
-        top = scored[:k]
 
         ids: List[str] = []
         documents: List[str] = []
         distances: List[float] = []
+        metadatas: List[dict] = []
+        language_filter = language_filter.lower() if language_filter else None
 
-        for idx, norm in top:
+        for idx, norm in scored:
             chunk = self._chunks[idx]
+            if language_filter and chunk["language"] != language_filter:
+                continue
+            if collections and chunk["collection"] not in collections:
+                continue
             ids.append(chunk["id"])
             documents.append(chunk["text"])
             distances.append(round(1.0 - norm, 6))
+            metadatas.append({
+                "source": chunk["source"],
+                "collection": chunk["collection"],
+                "language": chunk["language"],
+            })
+            if len(ids) >= k:
+                break
 
-        return {"ids": [ids], "documents": [documents], "distances": [distances]}
+        return {"ids": [ids], "documents": [documents], "distances": [distances], "metadatas": [metadatas]}

--- a/alcove/index/keyword.py
+++ b/alcove/index/keyword.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from .language import detect_language
+from .language import get_language_detector
 
 
 class KeywordIndex:
@@ -23,6 +23,7 @@ class KeywordIndex:
         )
         self._bm25 = None
         self._chunks: List[Dict] = []
+        self._language_detector = None
 
     def _load(self):
         """Read chunks.jsonl, tokenize, and build BM25 index."""
@@ -45,7 +46,7 @@ class KeywordIndex:
                         "text": text,
                         "source": rec.get("source", ""),
                         "collection": rec.get("collection", "default"),
-                        "language": (rec.get("language") or detect_language(text)).lower(),
+                        "language": self._language_for_record(rec, text),
                     })
                     tokenized.append(text.lower().split())
 
@@ -53,6 +54,14 @@ class KeywordIndex:
             self._bm25 = BM25Okapi(tokenized)
         else:
             self._bm25 = None
+
+    def _language_for_record(self, rec: dict, text: str) -> str:
+        language = rec.get("language")
+        if language:
+            return str(language).lower()
+        if self._language_detector is None:
+            self._language_detector = get_language_detector()
+        return self._language_detector.detect(text).language.lower()
 
     def search(
         self,

--- a/alcove/index/language.py
+++ b/alcove/index/language.py
@@ -20,7 +20,7 @@ class LanguageDetector(Protocol):
     provider: str
 
     def detect(self, text: str) -> LanguageDetection:
-        raise NotImplementedError  # pragma: no cover
+        pass  # pragma: no cover
 
 
 _ENGLISH_MARKERS = {
@@ -106,12 +106,6 @@ class LangdetectLanguageDetector:
 
     def __init__(self, confidence_threshold: float | None = None):
         self.confidence_threshold = _confidence_threshold(confidence_threshold)
-
-    def detect(self, text: str) -> LanguageDetection:
-        sample = _sample_text(text)
-        if not sample:
-            return LanguageDetection(provider=self.provider)
-
         try:
             from langdetect import DetectorFactory, LangDetectException, detect_langs
         except Exception as exc:
@@ -121,9 +115,17 @@ class LangdetectLanguageDetector:
             ) from exc
 
         DetectorFactory.seed = 0
+        self._detect_langs = detect_langs
+        self._LangDetectException = LangDetectException
+
+    def detect(self, text: str) -> LanguageDetection:
+        sample = _sample_text(text)
+        if not sample:
+            return LanguageDetection(provider=self.provider)
+
         try:
-            candidates = detect_langs(sample)
-        except LangDetectException:
+            candidates = self._detect_langs(sample)
+        except self._LangDetectException:
             return LanguageDetection(provider=self.provider)
 
         if not candidates:
@@ -186,7 +188,8 @@ class OllamaLanguageDetector:
             or os.getenv("ALCOVE_LANGUAGE_OLLAMA_BASE_URL")
             or os.getenv("OLLAMA_BASE_URL", "http://127.0.0.1:11434")
         ).rstrip("/")
-        self.timeout = float(timeout or os.getenv("ALCOVE_LANGUAGE_TIMEOUT", "30"))
+        timeout_value = timeout if timeout is not None else os.getenv("ALCOVE_LANGUAGE_TIMEOUT", "30")
+        self.timeout = float(timeout_value)
 
     def detect(self, text: str) -> LanguageDetection:
         sample = _sample_text(text)
@@ -204,10 +207,8 @@ class OllamaLanguageDetector:
         }
         try:
             response = self._post("/api/generate", payload)
-        except urllib.error.HTTPError as exc:
-            raise RuntimeError(self._format_http_error(exc)) from exc
-        except urllib.error.URLError as exc:
-            raise RuntimeError(self._format_url_error(exc)) from exc
+        except (urllib.error.HTTPError, urllib.error.URLError):
+            return LanguageDetection(provider=self.provider)
 
         raw = response.get("response", "")
         try:
@@ -226,19 +227,6 @@ class OllamaLanguageDetector:
         )
         with urllib.request.urlopen(request, timeout=self.timeout) as response:
             return json.loads(response.read().decode("utf-8"))
-
-    def _format_http_error(self, exc: urllib.error.HTTPError) -> str:
-        return (
-            f"Ollama language detection failed with HTTP {exc.code} against "
-            f"{self.base_url} while using model {self.model_name!r}."
-        )
-
-    def _format_url_error(self, exc: urllib.error.URLError) -> str:
-        return (
-            f"Could not reach Ollama at {self.base_url} while using language "
-            f"model {self.model_name!r}: {exc.reason}"
-        )
-
 
 _BUILTIN_LANGUAGE_DETECTORS = {
     "none": NoneLanguageDetector,
@@ -265,10 +253,11 @@ def get_language_detector(provider: str | None = None) -> LanguageDetector:
     from alcove.plugins import discover_language_detectors
 
     cfg = load_config().language
-    choice = _normalize_language(provider or cfg.provider)
+    raw_choice = (provider or cfg.provider or "").strip().lower()
+    choice = _normalize_language(raw_choice)
     detectors = dict(_BUILTIN_LANGUAGE_DETECTORS)
     detectors.update(discover_language_detectors())
-    cls = detectors.get(choice)
+    cls = detectors.get(choice) or detectors.get(raw_choice)
     if cls is None:
         raise ValueError(f"Unknown language detector: {choice!r}.")
 

--- a/alcove/index/language.py
+++ b/alcove/index/language.py
@@ -1,6 +1,26 @@
 from __future__ import annotations
 
+import json
+import os
 import re
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class LanguageDetection:
+    language: str = "unknown"
+    confidence: float | None = None
+    provider: str = "unknown"
+
+
+class LanguageDetector(Protocol):
+    provider: str
+
+    def detect(self, text: str) -> LanguageDetection:
+        ...  # pragma: no cover
 
 
 _ENGLISH_MARKERS = {
@@ -21,54 +41,259 @@ _FRENCH_MARKERS = {
 }
 
 
-def _detect_language_heuristic(sample: str) -> str:
-    lowered = sample.lower()
-    if any(ch in lowered for ch in "ñ¿¡ü"):
-        return "es"
-    if any(ch in lowered for ch in "âêîôûœæç"):
-        return "fr"
-
-    tokens = re.findall(r"[a-zA-Záéíóúñüàâçèêëîïôùûœæ]+", lowered)
-    if not tokens:
+def _normalize_language(value: object) -> str:
+    if value is None:
         return "unknown"
-
-    scores = {
-        "en": sum(token in _ENGLISH_MARKERS for token in tokens),
-        "es": sum(token in _SPANISH_MARKERS for token in tokens),
-        "fr": sum(token in _FRENCH_MARKERS for token in tokens),
-    }
-    best_lang, best_score = max(scores.items(), key=lambda item: item[1])
-    second_best = sorted(scores.values(), reverse=True)[1]
-    if best_score >= 2 and best_score > second_best:
-        return best_lang
-    return "unknown"
+    normalized = str(value).strip().lower().replace("_", "-")
+    return normalized or "unknown"
 
 
-def detect_language(text: str) -> str:
-    """Return a best-effort ISO 639 language code for chunk metadata.
-
-    Alcove keeps language detection local. If ``langdetect`` is installed, use
-    it with a fixed seed for repeatable output. Otherwise, fall back to a small
-    deterministic heuristic that covers common scripts and basic en/es/fr text.
-    """
+def _sample_text(text: str) -> str:
+    try:
+        limit = int(os.getenv("ALCOVE_LANGUAGE_MAX_CHARS", "4000"))
+    except ValueError:
+        limit = 4000
     sample = (text or "").strip()
-    if not sample:
-        return "unknown"
+    return sample[: max(1, limit)]
 
-    if re.search(r"[\u0400-\u04FF]", sample):
-        return "ru"
-    if re.search(r"[\u4E00-\u9FFF]", sample):
-        return "zh"
-    if re.search(r"[\u0600-\u06FF]", sample):
-        return "ar"
 
+class NoneLanguageDetector:
+    provider = "none"
+
+    def detect(self, text: str) -> LanguageDetection:
+        return LanguageDetection(provider=self.provider)
+
+
+class HeuristicLanguageDetector:
+    provider = "heuristic"
+
+    def detect(self, text: str) -> LanguageDetection:
+        sample = _sample_text(text)
+        if not sample:
+            return LanguageDetection(provider=self.provider)
+
+        if re.search(r"[\u0400-\u04FF]", sample):
+            return LanguageDetection("ru", 1.0, self.provider)
+        if re.search(r"[\u4E00-\u9FFF]", sample):
+            return LanguageDetection("zh", 1.0, self.provider)
+        if re.search(r"[\u0600-\u06FF]", sample):
+            return LanguageDetection("ar", 1.0, self.provider)
+
+        lowered = sample.lower()
+        if any(ch in lowered for ch in "ñ¿¡ü"):
+            return LanguageDetection("es", 1.0, self.provider)
+        if any(ch in lowered for ch in "âêîôûœæç"):
+            return LanguageDetection("fr", 1.0, self.provider)
+
+        tokens = re.findall(r"[a-zA-Záéíóúñüàâçèêëîïôùûœæ]+", lowered)
+        if not tokens:
+            return LanguageDetection(provider=self.provider)
+
+        scores = {
+            "en": sum(token in _ENGLISH_MARKERS for token in tokens),
+            "es": sum(token in _SPANISH_MARKERS for token in tokens),
+            "fr": sum(token in _FRENCH_MARKERS for token in tokens),
+        }
+        best_lang, best_score = max(scores.items(), key=lambda item: item[1])
+        second_best = sorted(scores.values(), reverse=True)[1]
+        if best_score >= 2 and best_score > second_best:
+            return LanguageDetection(best_lang, best_score / len(tokens), self.provider)
+        return LanguageDetection(provider=self.provider)
+
+
+class LangdetectLanguageDetector:
+    provider = "langdetect"
+
+    def __init__(self, confidence_threshold: float | None = None):
+        self.confidence_threshold = _confidence_threshold(confidence_threshold)
+
+    def detect(self, text: str) -> LanguageDetection:
+        sample = _sample_text(text)
+        if not sample:
+            return LanguageDetection(provider=self.provider)
+
+        try:
+            from langdetect import DetectorFactory, LangDetectException, detect_langs
+        except Exception as exc:
+            raise RuntimeError(
+                "ALCOVE_LANGUAGE_PROVIDER=langdetect requires the optional "
+                "`langdetect` package."
+            ) from exc
+
+        DetectorFactory.seed = 0
+        try:
+            candidates = detect_langs(sample)
+        except LangDetectException:
+            return LanguageDetection(provider=self.provider)
+
+        if not candidates:
+            return LanguageDetection(provider=self.provider)
+        best = candidates[0]
+        confidence = float(best.prob)
+        if confidence < self.confidence_threshold:
+            return LanguageDetection(confidence=confidence, provider=self.provider)
+        return LanguageDetection(_normalize_language(best.lang), confidence, self.provider)
+
+
+class TransformersLanguageDetector:
+    provider = "transformers"
+
+    def __init__(
+        self,
+        model_name: str | None = None,
+        confidence_threshold: float | None = None,
+    ):
+        self.model_name = model_name or os.getenv(
+            "ALCOVE_LANGUAGE_MODEL",
+            "papluca/xlm-roberta-base-language-detection",
+        )
+        self.confidence_threshold = _confidence_threshold(confidence_threshold)
+        try:
+            from transformers import pipeline
+        except Exception as exc:
+            raise RuntimeError(
+                "ALCOVE_LANGUAGE_PROVIDER=transformers requires the optional "
+                "`transformers` package and a supported local model runtime."
+            ) from exc
+        self._classifier = pipeline("text-classification", model=self.model_name)
+
+    def detect(self, text: str) -> LanguageDetection:
+        sample = _sample_text(text)
+        if not sample:
+            return LanguageDetection(provider=self.provider)
+        result = self._classifier(sample, truncation=True)
+        if isinstance(result, list):
+            result = result[0] if result else {}
+        label = _normalize_language(result.get("label") if isinstance(result, dict) else None)
+        confidence = float(result.get("score", 0.0)) if isinstance(result, dict) else 0.0
+        if confidence < self.confidence_threshold:
+            return LanguageDetection(confidence=confidence, provider=self.provider)
+        return LanguageDetection(label, confidence, self.provider)
+
+
+class OllamaLanguageDetector:
+    provider = "ollama"
+
+    def __init__(
+        self,
+        model_name: str | None = None,
+        base_url: str | None = None,
+        timeout: float | None = None,
+    ):
+        self.model_name = model_name or os.getenv("ALCOVE_LANGUAGE_MODEL", "llama3.2")
+        self.base_url = (
+            base_url
+            or os.getenv("ALCOVE_LANGUAGE_OLLAMA_BASE_URL")
+            or os.getenv("OLLAMA_BASE_URL", "http://127.0.0.1:11434")
+        ).rstrip("/")
+        self.timeout = float(timeout or os.getenv("ALCOVE_LANGUAGE_TIMEOUT", "30"))
+
+    def detect(self, text: str) -> LanguageDetection:
+        sample = _sample_text(text)
+        if not sample:
+            return LanguageDetection(provider=self.provider)
+        payload = {
+            "model": self.model_name,
+            "stream": False,
+            "format": "json",
+            "prompt": (
+                "Return only JSON like {\"language\":\"en\"}. Identify the ISO 639-1 "
+                "language code for this text. Use \"unknown\" if uncertain.\n\n"
+                f"{sample}"
+            ),
+        }
+        try:
+            response = self._post("/api/generate", payload)
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(self._format_http_error(exc)) from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(self._format_url_error(exc)) from exc
+
+        raw = response.get("response", "")
+        try:
+            data = json.loads(raw) if isinstance(raw, str) else raw
+        except json.JSONDecodeError:
+            data = {}
+        return LanguageDetection(_normalize_language(data.get("language")), provider=self.provider)
+
+    def _post(self, path: str, payload: dict) -> dict:
+        body = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            f"{self.base_url}{path}",
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=self.timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    def _format_http_error(self, exc: urllib.error.HTTPError) -> str:
+        return (
+            f"Ollama language detection failed with HTTP {exc.code} against "
+            f"{self.base_url} while using model {self.model_name!r}."
+        )
+
+    def _format_url_error(self, exc: urllib.error.URLError) -> str:
+        return (
+            f"Could not reach Ollama at {self.base_url} while using language "
+            f"model {self.model_name!r}: {exc.reason}"
+        )
+
+
+_BUILTIN_LANGUAGE_DETECTORS = {
+    "none": NoneLanguageDetector,
+    "heuristic": HeuristicLanguageDetector,
+    "langdetect": LangdetectLanguageDetector,
+    "transformers": TransformersLanguageDetector,
+    "huggingface": TransformersLanguageDetector,
+    "ollama": OllamaLanguageDetector,
+}
+
+
+def _confidence_threshold(value: float | None = None) -> float:
+    if value is not None:
+        return min(1.0, max(0.0, float(value)))
     try:
-        from langdetect import DetectorFactory, LangDetectException, detect
-    except Exception:
-        return _detect_language_heuristic(sample)
+        threshold = float(os.getenv("ALCOVE_LANGUAGE_CONFIDENCE_THRESHOLD", "0.0"))
+        return min(1.0, max(0.0, threshold))
+    except ValueError:
+        return 0.0
 
-    DetectorFactory.seed = 0
-    try:
-        return detect(sample)
-    except LangDetectException:
-        return _detect_language_heuristic(sample)
+
+def get_language_detector(provider: str | None = None) -> LanguageDetector:
+    from alcove.config import load_config
+    from alcove.plugins import discover_language_detectors
+
+    cfg = load_config().language
+    choice = _normalize_language(provider or cfg.provider)
+    detectors = dict(_BUILTIN_LANGUAGE_DETECTORS)
+    detectors.update(discover_language_detectors())
+    cls = detectors.get(choice)
+    if cls is None:
+        raise ValueError(f"Unknown language detector: {choice!r}.")
+
+    if choice in {"langdetect"}:
+        return cls(confidence_threshold=cfg.confidence_threshold)
+    if choice in {"transformers", "huggingface"}:
+        return cls(
+            model_name=cfg.model,
+            confidence_threshold=cfg.confidence_threshold,
+        )
+    if choice == "ollama":
+        return cls(
+            model_name=cfg.model,
+            base_url=cfg.ollama_base_url,
+            timeout=cfg.timeout,
+        )
+    return cls()
+
+
+def detect_language(text: str, detector: LanguageDetector | None = None) -> str:
+    """Return an ISO 639 language code for chunk metadata.
+
+    This compatibility helper delegates to the configured language detector.
+    New indexing code should construct a detector once with
+    ``get_language_detector()`` and reuse it across chunks.
+    """
+    detector = detector or get_language_detector()
+    return detector.detect(text).language

--- a/alcove/index/language.py
+++ b/alcove/index/language.py
@@ -23,7 +23,7 @@ _FRENCH_MARKERS = {
 
 def _detect_language_heuristic(sample: str) -> str:
     lowered = sample.lower()
-    if any(ch in lowered for ch in "ñ¿¡"):
+    if any(ch in lowered for ch in "ñ¿¡ü"):
         return "es"
     if any(ch in lowered for ch in "âêîôûœæç"):
         return "fr"

--- a/alcove/index/language.py
+++ b/alcove/index/language.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import re
+
+
+_ENGLISH_MARKERS = {
+    "the", "and", "in", "of", "to", "with", "for", "from", "this", "that",
+    "history", "family", "interview", "interviews", "traditions", "detail",
+    "work", "community",
+}
+_SPANISH_MARKERS = {
+    "el", "la", "las", "los", "de", "del", "y", "en", "con", "para", "por",
+    "una", "un", "familia", "historia", "entrevista", "entrevistas",
+    "tradiciones", "memoria", "migracion", "trabajo", "comunidad",
+}
+_FRENCH_MARKERS = {
+    "le", "les", "des", "une", "et", "en", "du", "au", "aux", "ce",
+    "est", "dans", "sur", "par", "pour", "avec", "que", "qui",
+    "histoire", "famille", "entretien", "traditions", "memoire",
+    "travail", "communaute", "recherche",
+}
+
+
+def _detect_language_heuristic(sample: str) -> str:
+    lowered = sample.lower()
+    if any(ch in lowered for ch in "ñ¿¡"):
+        return "es"
+    if any(ch in lowered for ch in "âêîôûœæç"):
+        return "fr"
+
+    tokens = re.findall(r"[a-zA-Záéíóúñüàâçèêëîïôùûüœæ]+", lowered)
+    if not tokens:
+        return "unknown"
+
+    scores = {
+        "en": sum(token in _ENGLISH_MARKERS for token in tokens),
+        "es": sum(token in _SPANISH_MARKERS for token in tokens),
+        "fr": sum(token in _FRENCH_MARKERS for token in tokens),
+    }
+    best_lang, best_score = max(scores.items(), key=lambda item: item[1])
+    second_best = sorted(scores.values(), reverse=True)[1]
+    if best_score >= 2 and best_score > second_best:
+        return best_lang
+    return "unknown"
+
+
+def detect_language(text: str) -> str:
+    """Return a best-effort ISO 639 language code for chunk metadata.
+
+    Alcove keeps language detection local. If ``langdetect`` is installed, use
+    it with a fixed seed for repeatable output. Otherwise, fall back to a small
+    deterministic heuristic that covers common scripts and basic en/es/fr text.
+    """
+    sample = (text or "").strip()
+    if not sample:
+        return "unknown"
+
+    if re.search(r"[\u0400-\u04FF]", sample):
+        return "ru"
+    if re.search(r"[\u4E00-\u9FFF]", sample):
+        return "zh"
+    if re.search(r"[\u0600-\u06FF]", sample):
+        return "ar"
+
+    try:
+        from langdetect import DetectorFactory, LangDetectException, detect
+    except Exception:
+        return _detect_language_heuristic(sample)
+
+    DetectorFactory.seed = 0
+    try:
+        return detect(sample)
+    except LangDetectException:
+        return _detect_language_heuristic(sample)

--- a/alcove/index/language.py
+++ b/alcove/index/language.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import ipaddress
 import json
 import os
 import re
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from typing import Protocol
@@ -48,13 +50,10 @@ def _normalize_language(value: object) -> str:
     return normalized or "unknown"
 
 
-def _sample_text(text: str) -> str:
-    try:
-        limit = int(os.getenv("ALCOVE_LANGUAGE_MAX_CHARS", "4000"))
-    except ValueError:
-        limit = 4000
+def _sample_text(text: str, max_chars: int = 4000) -> str:
+    limit = max(1, max_chars)
     sample = (text or "").strip()
-    return sample[: max(1, limit)]
+    return sample[:limit]
 
 
 class NoneLanguageDetector:
@@ -67,8 +66,11 @@ class NoneLanguageDetector:
 class HeuristicLanguageDetector:
     provider = "heuristic"
 
+    def __init__(self, max_chars: int = 4000):
+        self.max_chars = max_chars
+
     def detect(self, text: str) -> LanguageDetection:
-        sample = _sample_text(text)
+        sample = _sample_text(text, self.max_chars)
         if not sample:
             return LanguageDetection(provider=self.provider)
 
@@ -104,8 +106,9 @@ class HeuristicLanguageDetector:
 class LangdetectLanguageDetector:
     provider = "langdetect"
 
-    def __init__(self, confidence_threshold: float | None = None):
+    def __init__(self, confidence_threshold: float | None = None, max_chars: int = 4000):
         self.confidence_threshold = _confidence_threshold(confidence_threshold)
+        self.max_chars = max_chars
         try:
             from langdetect import DetectorFactory, LangDetectException, detect_langs
         except Exception as exc:
@@ -119,7 +122,7 @@ class LangdetectLanguageDetector:
         self._LangDetectException = LangDetectException
 
     def detect(self, text: str) -> LanguageDetection:
-        sample = _sample_text(text)
+        sample = _sample_text(text, self.max_chars)
         if not sample:
             return LanguageDetection(provider=self.provider)
 
@@ -144,12 +147,14 @@ class TransformersLanguageDetector:
         self,
         model_name: str | None = None,
         confidence_threshold: float | None = None,
+        max_chars: int = 4000,
     ):
         self.model_name = model_name or os.getenv(
             "ALCOVE_LANGUAGE_MODEL",
             "papluca/xlm-roberta-base-language-detection",
         )
         self.confidence_threshold = _confidence_threshold(confidence_threshold)
+        self.max_chars = max_chars
         try:
             from transformers import pipeline
         except Exception as exc:
@@ -160,7 +165,7 @@ class TransformersLanguageDetector:
         self._classifier = pipeline("text-classification", model=self.model_name)
 
     def detect(self, text: str) -> LanguageDetection:
-        sample = _sample_text(text)
+        sample = _sample_text(text, self.max_chars)
         if not sample:
             return LanguageDetection(provider=self.provider)
         result = self._classifier(sample, truncation=True)
@@ -181,6 +186,7 @@ class OllamaLanguageDetector:
         model_name: str | None = None,
         base_url: str | None = None,
         timeout: float | None = None,
+        max_chars: int = 4000,
     ):
         self.model_name = model_name or os.getenv("ALCOVE_LANGUAGE_MODEL", "llama3.2")
         self.base_url = (
@@ -188,11 +194,14 @@ class OllamaLanguageDetector:
             or os.getenv("ALCOVE_LANGUAGE_OLLAMA_BASE_URL")
             or os.getenv("OLLAMA_BASE_URL", "http://127.0.0.1:11434")
         ).rstrip("/")
+        if not _is_local_ollama_url(self.base_url):
+            raise ValueError("Ollama language detection requires a loopback base URL.")
         timeout_value = timeout if timeout is not None else os.getenv("ALCOVE_LANGUAGE_TIMEOUT", "30")
         self.timeout = float(timeout_value)
+        self.max_chars = max_chars
 
     def detect(self, text: str) -> LanguageDetection:
-        sample = _sample_text(text)
+        sample = _sample_text(text, self.max_chars)
         if not sample:
             return LanguageDetection(provider=self.provider)
         payload = {
@@ -207,13 +216,17 @@ class OllamaLanguageDetector:
         }
         try:
             response = self._post("/api/generate", payload)
-        except (urllib.error.HTTPError, urllib.error.URLError):
+        except (json.JSONDecodeError, TypeError, UnicodeDecodeError, urllib.error.HTTPError, urllib.error.URLError):
             return LanguageDetection(_normalize_language(None), provider=self.provider)
 
+        if not isinstance(response, dict):
+            return LanguageDetection(_normalize_language(None), provider=self.provider)
         raw = response.get("response", "")
         try:
             data = json.loads(raw) if isinstance(raw, str) else raw
         except json.JSONDecodeError:
+            data = {}
+        if not isinstance(data, dict):
             data = {}
         return LanguageDetection(_normalize_language(data.get("language")), provider=self.provider)
 
@@ -227,6 +240,21 @@ class OllamaLanguageDetector:
         )
         with urllib.request.urlopen(request, timeout=self.timeout) as response:
             return json.loads(response.read().decode("utf-8"))
+
+
+def _is_local_ollama_url(base_url: str) -> bool:
+    parsed = urllib.parse.urlparse(base_url)
+    if parsed.scheme not in {"http", "https"}:
+        return False
+    host = parsed.hostname
+    if host is None:
+        return False
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
 
 _BUILTIN_LANGUAGE_DETECTORS = {
     "none": NoneLanguageDetector,
@@ -262,18 +290,25 @@ def get_language_detector(provider: str | None = None) -> LanguageDetector:
         raise ValueError(f"Unknown language detector: {choice!r}.")
 
     if choice in {"langdetect"}:
-        return cls(confidence_threshold=cfg.confidence_threshold)
+        return cls(
+            confidence_threshold=cfg.confidence_threshold,
+            max_chars=cfg.max_chars,
+        )
     if choice in {"transformers", "huggingface"}:
         return cls(
             model_name=cfg.model,
             confidence_threshold=cfg.confidence_threshold,
+            max_chars=cfg.max_chars,
         )
     if choice == "ollama":
         return cls(
             model_name=cfg.model,
             base_url=cfg.ollama_base_url,
             timeout=cfg.timeout,
+            max_chars=cfg.max_chars,
         )
+    if choice == "heuristic":
+        return cls(max_chars=cfg.max_chars)
     return cls()
 
 

--- a/alcove/index/language.py
+++ b/alcove/index/language.py
@@ -20,7 +20,7 @@ class LanguageDetector(Protocol):
     provider: str
 
     def detect(self, text: str) -> LanguageDetection:
-        ...  # pragma: no cover
+        raise NotImplementedError  # pragma: no cover
 
 
 _ENGLISH_MARKERS = {

--- a/alcove/index/language.py
+++ b/alcove/index/language.py
@@ -28,7 +28,7 @@ def _detect_language_heuristic(sample: str) -> str:
     if any(ch in lowered for ch in "âêîôûœæç"):
         return "fr"
 
-    tokens = re.findall(r"[a-zA-Záéíóúñüàâçèêëîïôùûüœæ]+", lowered)
+    tokens = re.findall(r"[a-zA-Záéíóúñüàâçèêëîïôùûœæ]+", lowered)
     if not tokens:
         return "unknown"
 

--- a/alcove/index/language.py
+++ b/alcove/index/language.py
@@ -208,7 +208,7 @@ class OllamaLanguageDetector:
         try:
             response = self._post("/api/generate", payload)
         except (urllib.error.HTTPError, urllib.error.URLError):
-            return LanguageDetection(provider=self.provider)
+            return LanguageDetection(_normalize_language(None), provider=self.provider)
 
         raw = response.get("response", "")
         try:

--- a/alcove/index/pipeline.py
+++ b/alcove/index/pipeline.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from .backend import get_backend
 from .embedder import get_embedder
-from .language import detect_language
+from .language import get_language_detector
 
 
 def run(chunks_file: str | None = None, collection: str = "default") -> int:
@@ -14,18 +14,24 @@ def run(chunks_file: str | None = None, collection: str = "default") -> int:
 
     embedder = get_embedder()
     backend = get_backend(embedder)
+    language_detector = None
 
     ids, docs, metas = [], [], []
     with Path(chunks_file).open("r", encoding="utf-8") as f:
         for line in f:
             rec = json.loads(line)
             chunk = rec["chunk"]
+            language = rec.get("language")
+            if not language:
+                if language_detector is None:
+                    language_detector = get_language_detector()
+                language = language_detector.detect(chunk).language
             ids.append(rec["id"])
             docs.append(chunk)
             metas.append({
                 "source": rec["source"],
                 "collection": collection,
-                "language": (rec.get("language") or detect_language(chunk)).lower(),
+                "language": str(language).lower(),
             })
 
     if not ids:

--- a/alcove/index/pipeline.py
+++ b/alcove/index/pipeline.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from .backend import get_backend
 from .embedder import get_embedder
+from .language import detect_language
 
 
 def run(chunks_file: str | None = None, collection: str = "default") -> int:
@@ -18,9 +19,14 @@ def run(chunks_file: str | None = None, collection: str = "default") -> int:
     with Path(chunks_file).open("r", encoding="utf-8") as f:
         for line in f:
             rec = json.loads(line)
+            chunk = rec["chunk"]
             ids.append(rec["id"])
-            docs.append(rec["chunk"])
-            metas.append({"source": rec["source"], "collection": collection})
+            docs.append(chunk)
+            metas.append({
+                "source": rec["source"],
+                "collection": collection,
+                "language": (rec.get("language") or detect_language(chunk)).lower(),
+            })
 
     if not ids:
         return 0

--- a/alcove/plugins.py
+++ b/alcove/plugins.py
@@ -25,6 +25,7 @@ else:
 EXTRACTORS_GROUP = "alcove.extractors"
 BACKENDS_GROUP = "alcove.backends"
 EMBEDDERS_GROUP = "alcove.embedders"
+LANGUAGE_DETECTORS_GROUP = "alcove.language_detectors"
 
 
 def discover_extractors() -> Dict[str, callable]:
@@ -46,6 +47,11 @@ def discover_embedders() -> Dict[str, type]:
     return {ep.name: ep.load() for ep in entry_points(group=EMBEDDERS_GROUP)}
 
 
+def discover_language_detectors() -> Dict[str, type]:
+    """Return {"name": LanguageDetectorClass} from installed plugins."""
+    return {ep.name: ep.load() for ep in entry_points(group=LANGUAGE_DETECTORS_GROUP)}
+
+
 def list_plugins() -> List[dict]:
     """List all discovered Alcove plugins across all groups."""
     plugins = []
@@ -53,6 +59,7 @@ def list_plugins() -> List[dict]:
         (EXTRACTORS_GROUP, "extractor"),
         (BACKENDS_GROUP, "backend"),
         (EMBEDDERS_GROUP, "embedder"),
+        (LANGUAGE_DETECTORS_GROUP, "language_detector"),
     ]:
         for ep in entry_points(group=group):
             plugins.append({

--- a/alcove/query/api.py
+++ b/alcove/query/api.py
@@ -142,7 +142,7 @@ def search(
         if invalid:
             return JSONResponse(
                 status_code=422,
-                content={"detail": f"Invalid collection name(s): {invalid}"},
+                content={"detail": "Invalid collection name."},
             )
         coll_list = tokens
     results: list = []

--- a/alcove/query/api.py
+++ b/alcove/query/api.py
@@ -48,6 +48,7 @@ class QueryIn(BaseModel):
     query: str
     k: int = 3
     collections: Optional[List[str]] = None
+    language_filter: Optional[str] = None
     mode: str = "semantic"
 
 
@@ -125,7 +126,14 @@ def demos_index(request: Request):
 
 
 @app.get("/search", response_class=HTMLResponse)
-def search(request: Request, q: str = "", k: int = 5, collections: str = "", mode: str = "semantic"):
+def search(
+    request: Request,
+    q: str = "",
+    k: int = 5,
+    collections: str = "",
+    mode: str = "semantic",
+    language_filter: str = "",
+):
     _COLL_RE = re.compile(r"^[a-zA-Z0-9_\-\.]{1,128}$")
     coll_list: Optional[List[str]] = None
     if collections.strip():
@@ -139,7 +147,13 @@ def search(request: Request, q: str = "", k: int = 5, collections: str = "", mod
         coll_list = tokens
     results: list = []
     if q.strip():
-        raw = _dispatch_query(q, k, mode=mode, collections=coll_list)
+        raw = _dispatch_query(
+            q,
+            k,
+            mode=mode,
+            collections=coll_list,
+            language_filter=language_filter or None,
+        )
         documents = raw.get("documents", [[]])[0]
         metadatas = raw.get("metadatas", [[]])[0]
         distances = raw.get("distances", [[]])[0]
@@ -151,6 +165,7 @@ def search(request: Request, q: str = "", k: int = 5, collections: str = "", mod
                 "text": highlighted,
                 "source": meta.get("source", "unknown") if isinstance(meta, dict) else "unknown",
                 "collection": meta.get("collection", "default") if isinstance(meta, dict) else "default",
+                "language": meta.get("language", "unknown") if isinstance(meta, dict) else "unknown",
                 "score": round(1.0 - dist, 3) if dist <= 1.0 else round(dist, 3),
             })
 
@@ -163,7 +178,13 @@ def search(request: Request, q: str = "", k: int = 5, collections: str = "", mod
 
 @app.post("/query")
 def query(inp: QueryIn):
-    return _dispatch_query(inp.query, inp.k, mode=inp.mode, collections=inp.collections)
+    return _dispatch_query(
+        inp.query,
+        inp.k,
+        mode=inp.mode,
+        collections=inp.collections,
+        language_filter=inp.language_filter,
+    )
 
 
 @app.post("/ingest")
@@ -265,14 +286,26 @@ def _dispatch_query(
     k: int,
     mode: str = "semantic",
     collections: Optional[List[str]] = None,
+    language_filter: Optional[str] = None,
 ) -> dict:
     """Route to the correct retriever based on search mode."""
     if mode == "keyword":
-        return query_keyword(q, n_results=k)
+        kwargs = {"n_results": k}
+        if collections is not None:
+            kwargs["collections"] = collections
+        if language_filter is not None:
+            kwargs["language_filter"] = language_filter
+        return query_keyword(q, **kwargs)
     elif mode == "hybrid":
-        return query_hybrid(q, n_results=k, collections=collections)
+        kwargs = {"n_results": k, "collections": collections}
+        if language_filter is not None:
+            kwargs["language_filter"] = language_filter
+        return query_hybrid(q, **kwargs)
     else:
-        return query_text(q, n_results=k, collections=collections)
+        kwargs = {"n_results": k, "collections": collections}
+        if language_filter is not None:
+            kwargs["language_filter"] = language_filter
+        return query_text(q, **kwargs)
 
 
 def _highlight(escaped_text: str, query: str) -> str:

--- a/alcove/query/retriever.py
+++ b/alcove/query/retriever.py
@@ -6,32 +6,60 @@ from alcove.index.backend import get_backend
 from alcove.index.embedder import get_embedder
 
 
-def query_text(q: str, n_results: int = 3, collections: Optional[List[str]] = None):
+def query_text(
+    q: str,
+    n_results: int = 3,
+    collections: Optional[List[str]] = None,
+    language_filter: Optional[str] = None,
+):
     embedder = get_embedder()
     backend = get_backend(embedder)
     emb = embedder.embed([q])[0]
-    return backend.query(emb, k=n_results, collections=collections)
+    return backend.query(
+        emb,
+        k=n_results,
+        collections=collections,
+        language_filter=language_filter,
+    )
 
 
-def query_keyword(q: str, n_results: int = 3) -> dict:
+def query_keyword(
+    q: str,
+    n_results: int = 3,
+    collections: Optional[List[str]] = None,
+    language_filter: Optional[str] = None,
+) -> dict:
     """Run a keyword (BM25) search over the chunks index."""
     from alcove.index.keyword import KeywordIndex
     idx = KeywordIndex()
-    return idx.search(q, k=n_results)
+    return idx.search(
+        q,
+        k=n_results,
+        collections=collections,
+        language_filter=language_filter,
+    )
 
 
 def query_hybrid(
     q: str,
     n_results: int = 3,
     collections: Optional[List[str]] = None,
+    language_filter: Optional[str] = None,
 ) -> dict:
     """Run both semantic and keyword search, merge by averaging scores.
 
     Deduplicates by document id. Returns top-k results sorted by
     combined score (lower distance = better match).
     """
-    semantic = query_text(q, n_results=n_results, collections=collections)
-    keyword = query_keyword(q, n_results=n_results)
+    semantic_kwargs = {"n_results": n_results, "collections": collections}
+    keyword_kwargs = {"n_results": n_results}
+    if collections is not None:
+        keyword_kwargs["collections"] = collections
+    if language_filter is not None:
+        semantic_kwargs["language_filter"] = language_filter
+        keyword_kwargs["language_filter"] = language_filter
+    semantic = query_text(q, **semantic_kwargs)
+    keyword = query_keyword(q, **keyword_kwargs)
 
     # Collect per-id scores from both result sets.
     merged: Dict[str, dict] = {}

--- a/alcove/query/retriever.py
+++ b/alcove/query/retriever.py
@@ -52,9 +52,7 @@ def query_hybrid(
     combined score (lower distance = better match).
     """
     semantic_kwargs = {"n_results": n_results, "collections": collections}
-    keyword_kwargs = {"n_results": n_results}
-    if collections is not None:
-        keyword_kwargs["collections"] = collections
+    keyword_kwargs = {"n_results": n_results, "collections": collections}
     if language_filter is not None:
         semantic_kwargs["language_filter"] = language_filter
         keyword_kwargs["language_filter"] = language_filter

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,6 +44,22 @@ data/raw/*  →  data/processed/chunks.jsonl  →  vector store  →  query resp
 
 Set the embedder with the `EMBEDDER` environment variable. See [OPERATIONS.md](OPERATIONS.md#environment-variables) for how to configure it. Custom embedders can be installed as plugins.
 
+## Language metadata
+
+Language detection is an indexing concern, not a retrieval dependency. During indexing,
+Alcove writes a `language` metadata field for each chunk when the source chunk does not
+already provide one. Query-time language filters only use stored metadata.
+
+| Provider | Env value | Description |
+|----------|-----------|-------------|
+| None | `ALCOVE_LANGUAGE_PROVIDER=none` | Do not infer language metadata. Existing chunk metadata is still preserved. |
+| Heuristic (default) | `ALCOVE_LANGUAGE_PROVIDER=heuristic` | Deterministic local rules for common scripts and basic English, Spanish, and French text. |
+| langdetect | `ALCOVE_LANGUAGE_PROVIDER=langdetect` | Optional local library for probabilistic language ID. |
+| Hugging Face | `ALCOVE_LANGUAGE_PROVIDER=transformers` or `huggingface` | Optional local `transformers` text-classification model such as `papluca/xlm-roberta-base-language-detection`. |
+| Ollama | `ALCOVE_LANGUAGE_PROVIDER=ollama` | Optional local Ollama classifier. Sends sampled chunk text only to the configured Ollama base URL. |
+
+Custom detectors can be installed as plugins through `alcove.language_detectors`.
+
 ## Vector backends
 
 | Name | Env value | Dependency |
@@ -55,13 +71,14 @@ Set the backend with the `VECTOR_BACKEND` environment variable. See [OPERATIONS.
 
 ## Plugin system
 
-Custom extractors, embedders, and vector backends plug in via [Python entry points](https://packaging.python.org/en/latest/specifications/entry-points/). Three extension groups:
+Custom extractors, embedders, language detectors, and vector backends plug in via [Python entry points](https://packaging.python.org/en/latest/specifications/entry-points/). Four extension groups:
 
 | Group | Purpose | Example entry point |
 |-------|---------|---------------------|
 | `alcove.extractors` | Add file format support | `rtf = my_plugin:extract_rtf` |
 | `alcove.backends` | Add vector store backends | `pinecone = my_plugin:PineconeBackend` |
 | `alcove.embedders` | Add embedding models | `openai = my_plugin:OpenAIEmbedder` |
+| `alcove.language_detectors` | Add language metadata detectors | `custom = my_plugin:LanguageDetector` |
 
 To create a plugin, add an `[project.entry-points]` section in your package's `pyproject.toml`:
 
@@ -74,7 +91,7 @@ Plugins are merged with built-ins at startup. When a plugin and a built-in share
 
 ## Boundary
 
-The operator owns the host and the storage. Alcove makes no outbound network calls by default; the one exception is `sentence-transformers`, which downloads a model on first use and then runs locally. `EMBEDDER=ollama` sends chunk text only to the Ollama base URL the operator configures, defaulting to the local loopback interface. Telemetry is disabled, including ChromaDB's upstream telemetry. See [SECURITY.md](SECURITY.md#security-model) for the full security model.
+The operator owns the host and the storage. Alcove makes no outbound network calls by default; the one exception is `sentence-transformers`, which downloads a model on first use and then runs locally. `EMBEDDER=ollama` and `ALCOVE_LANGUAGE_PROVIDER=ollama` send chunk text only to the Ollama base URL the operator configures, defaulting to the local loopback interface. Hugging Face language detection may download the configured model on first use, then runs locally. Telemetry is disabled, including ChromaDB's upstream telemetry. See [SECURITY.md](SECURITY.md#security-model) for the full security model.
 
 This boundary is structural, not configurable. There is no flag to turn it off.
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -67,6 +67,12 @@ Bind to a non-localhost address only after reviewing [Security: Operator Respons
 | `OLLAMA_MODEL` | `nomic-embed-text` | Ollama embedding model when `EMBEDDER=ollama` |
 | `OLLAMA_TIMEOUT` | `60` | Ollama request timeout in seconds |
 | `OLLAMA_DIM` | `768` | Ollama embedding dimension for backends that need it at initialization |
+| `ALCOVE_LANGUAGE_PROVIDER` | `heuristic` | Language metadata detector (`none`, `heuristic`, `langdetect`, `transformers`, `huggingface`, `ollama`, or plugin name) |
+| `ALCOVE_LANGUAGE_MODEL` | provider-specific | Hugging Face or Ollama model for language detection |
+| `ALCOVE_LANGUAGE_CONFIDENCE_THRESHOLD` | `0.0` | Minimum detector confidence before writing a language code |
+| `ALCOVE_LANGUAGE_OLLAMA_BASE_URL` | `OLLAMA_BASE_URL` or `http://127.0.0.1:11434` | Local Ollama base URL for `ALCOVE_LANGUAGE_PROVIDER=ollama` |
+| `ALCOVE_LANGUAGE_TIMEOUT` | `30` | Ollama language detection timeout in seconds |
+| `ALCOVE_LANGUAGE_MAX_CHARS` | `4000` | Maximum characters sampled per chunk for language detection |
 | `VECTOR_BACKEND` | `chromadb` | Vector store (`chromadb` or `zvec`) |
 | `CHROMA_PATH` | `./data/chroma` | ChromaDB persistence directory |
 | `CHROMA_COLLECTION` | `alcove_docs` | Collection name |

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -80,10 +80,12 @@ Bind to a non-localhost address only after reviewing [Security: Operator Respons
 | `CHUNK_OVERLAP` | `150` | Overlap between chunks |
 | `RAW_DIR` | `data/raw` | Input directory for ingestion |
 
-`ALCOVE_LANGUAGE_OLLAMA_BASE_URL` deliberately falls back to `OLLAMA_BASE_URL`
-so embedding and language detection can share one local Ollama host. Set
-`ALCOVE_LANGUAGE_OLLAMA_BASE_URL` explicitly when the language detector should
-use a different Ollama instance than `EMBEDDER=ollama`.
+`Language.ollama_base_url` is resolved from `ALCOVE_LANGUAGE_OLLAMA_BASE_URL`.
+When that variable is unset, the config resolver uses `OLLAMA_BASE_URL` as the
+fallback before defaulting to `http://127.0.0.1:11434`. This deliberately lets
+`EMBEDDER=ollama` and `ALCOVE_LANGUAGE_PROVIDER=ollama` share one local Ollama
+host. Set `ALCOVE_LANGUAGE_OLLAMA_BASE_URL` explicitly when language detection
+should use a different Ollama instance than embeddings.
 
 ## Docker
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -80,6 +80,11 @@ Bind to a non-localhost address only after reviewing [Security: Operator Respons
 | `CHUNK_OVERLAP` | `150` | Overlap between chunks |
 | `RAW_DIR` | `data/raw` | Input directory for ingestion |
 
+`ALCOVE_LANGUAGE_OLLAMA_BASE_URL` deliberately falls back to `OLLAMA_BASE_URL`
+so embedding and language detection can share one local Ollama host. Set
+`ALCOVE_LANGUAGE_OLLAMA_BASE_URL` explicitly when the language detector should
+use a different Ollama instance than `EMBEDDER=ollama`.
+
 ## Docker
 
 ```bash

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Current release (v0.3.0)
 
-Alcove ships a working three-stage pipeline: ingest, index, query. Eleven document formats. Three embedders (hash for offline determinism, sentence-transformers for local semantic search, Ollama for operator-managed local models). Two vector backends (ChromaDB, zvec). Local language metadata is written during indexing and can be used as a query filter. A plugin system.
+Alcove ships a working three-stage pipeline: ingest, index, query. Eleven document formats. Three embedders (hash for offline determinism, sentence-transformers for local semantic search, Ollama for operator-managed local models). Two vector backends (ChromaDB, zvec). Configurable local language metadata is written during indexing and can be used as a query filter. A plugin system.
 
 A web UI with upload and search. CI across Python 3.10, 3.11, 3.12. Docker deployment. Apache 2.0.
 
@@ -18,7 +18,7 @@ This is the foundation. Everything below builds on it.
 
 **Browse mode.** Alcove should be navigable, not just searchable. Directory-aware corpus browsing in the web UI: see what you have, not just what matches a query. Search and browse are complementary interfaces to the same index.
 
-**Language-aware browsing.** Language metadata now exists at chunk level. Near-term work is exposing it cleanly in the web UI and collection views so multilingual corpora can be filtered without changing the retrieval model.
+**Language-aware browsing.** Language metadata now exists at chunk level through configurable providers (`heuristic`, `langdetect`, Hugging Face, Ollama, or plugins). Near-term work is exposing it cleanly in the web UI and collection views so multilingual corpora can be filtered without changing the retrieval model.
 
 **MCP endpoint.** This is the "share it with the universe" part. An MCP-compatible retrieval surface lets AI tools, public-facing websites, or any other tool query your index. The first public step is a local STDIO MCP server that exposes search and collection-listing tools. Your corpus stays local. Your index stays yours. The answers are available to whoever you choose to expose them to. Because Alcove is retrieval, not generation, those answers are what your documents actually say: no hallucinations, no editorializing, no slop. [MCP changes the security surface](SECURITY.md#security-model); review it before exposing the endpoint. Context7 compatibility is a goal.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 ## Current release (v0.3.0)
 
-Alcove ships a working three-stage pipeline: ingest, index, query. Eleven document formats. Two embedders (hash for offline determinism, sentence-transformers for real semantic search). Two vector backends (ChromaDB, zvec). A plugin system.
+Alcove ships a working three-stage pipeline: ingest, index, query. Eleven document formats. Two embedders (hash for offline determinism, sentence-transformers for real semantic search). Two vector backends (ChromaDB, zvec). Local language metadata is written during indexing and can be used as a query filter. A plugin system.
 
 A web UI with upload and search. CI across Python 3.10, 3.11, 3.12. Docker deployment. Apache 2.0.
 
@@ -15,6 +15,8 @@ This is the foundation. Everything below builds on it.
 **Semantic search as default.** The hash embedder exists for zero-download offline bootstrapping and for operators who do not want ML in the pipeline. Once the onboarding experience is smooth enough, sentence-transformers (or a lighter alternative) becomes the default install. The hash embedder stays available: not a stepping stone, but a permanent option for people who want deterministic, inspectable results.
 
 **Browse mode.** Alcove should be navigable, not just searchable. Directory-aware corpus browsing in the web UI: see what you have, not just what matches a query. Search and browse are complementary interfaces to the same index.
+
+**Language-aware browsing.** Language metadata now exists at chunk level. Near-term work is exposing it cleanly in the web UI and collection views so multilingual corpora can be filtered without changing the retrieval model.
 
 **MCP endpoint.** This is the "share it with the universe" part. An MCP-compatible retrieval surface that lets AI tools, public-facing websites, or any other tool query your index. Your corpus stays local. Your index stays yours. The answers are available to whoever you choose to expose them to. Because Alcove is retrieval, not generation, those answers are what your documents actually say: no hallucinations, no editorializing, no slop. Alcove already runs a local API; exposing it as an MCP tool server is a natural extension. [MCP changes the security surface](SECURITY.md#security-model); review it before exposing the endpoint. Context7 compatibility is a goal.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = ["pytest>=8.3", "python-docx>=1.0", "python-pptx>=1.0", "httpx>=0.27", "de
 docx = ["python-docx>=1.0"]
 pptx = ["python-pptx>=1.0"]
 semantic = ["sentence-transformers>=3.0"]
+language = ["langdetect>=1.0.9", "transformers>=4.40"]
 epub = ["ebooklib>=0.18,<1.0"]
 zvec = ["zvec>=0.1"]
 tools = ["defusedxml>=0.7", "requests>=2.28"]

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -74,6 +74,89 @@ class TestChromaBackend:
 
         assert result["ids"] == [["es-doc"]]
 
+    def test_query_filters_by_language_no_matches(self, embedder, tmp_path, monkeypatch):
+        monkeypatch.setenv("CHROMA_PATH", str(tmp_path / "chroma"))
+        monkeypatch.setenv("CHROMA_COLLECTION", "test_col")
+        from alcove.index.backend import ChromaBackend
+
+        backend = ChromaBackend(embedder)
+        vecs = embedder.embed(["family history"])
+        backend.add(
+            ids=["en-doc"],
+            embeddings=vecs,
+            documents=["family history"],
+            metadatas=[{"source": "a.txt", "language": "en"}],
+        )
+
+        q_vec = embedder.embed(["historia"])[0]
+        result = backend.query(q_vec, k=2, language_filter="es")
+
+        assert result["ids"] == [[]]
+
+    def test_query_filters_by_language_and_collection(self, embedder, tmp_path, monkeypatch):
+        monkeypatch.setenv("CHROMA_PATH", str(tmp_path / "chroma"))
+        monkeypatch.setenv("CHROMA_COLLECTION", "test_col")
+        from alcove.index.backend import ChromaBackend
+
+        backend = ChromaBackend(embedder)
+        vecs = embedder.embed(["family history", "family history"])
+        backend.add(
+            ids=["letters-doc", "minutes-doc"],
+            embeddings=vecs,
+            documents=["family history", "family history"],
+            metadatas=[
+                {"source": "a.txt", "collection": "letters", "language": "en"},
+                {"source": "b.txt", "collection": "minutes", "language": "en"},
+            ],
+        )
+
+        q_vec = embedder.embed(["family"])[0]
+        result = backend.query(q_vec, k=2, collections=["minutes"], language_filter="en")
+
+        assert result["ids"] == [["minutes-doc"]]
+
+    def test_query_filters_by_language_case_insensitive(self, embedder, tmp_path, monkeypatch):
+        monkeypatch.setenv("CHROMA_PATH", str(tmp_path / "chroma"))
+        monkeypatch.setenv("CHROMA_COLLECTION", "test_col")
+        from alcove.index.backend import ChromaBackend
+
+        backend = ChromaBackend(embedder)
+        vecs = embedder.embed(["historia familiar"])
+        backend.add(
+            ids=["es-doc"],
+            embeddings=vecs,
+            documents=["historia familiar"],
+            metadatas=[{"source": "a.txt", "language": "es"}],
+        )
+
+        q_vec = embedder.embed(["historia"])[0]
+        result = backend.query(q_vec, k=2, language_filter="ES")
+
+        assert result["ids"] == [["es-doc"]]
+
+    def test_query_filters_multiple_docs_by_language(self, embedder, tmp_path, monkeypatch):
+        monkeypatch.setenv("CHROMA_PATH", str(tmp_path / "chroma"))
+        monkeypatch.setenv("CHROMA_COLLECTION", "test_col")
+        from alcove.index.backend import ChromaBackend
+
+        backend = ChromaBackend(embedder)
+        vecs = embedder.embed(["historia familiar", "memoria comunitaria", "family history"])
+        backend.add(
+            ids=["es-doc-1", "es-doc-2", "en-doc"],
+            embeddings=vecs,
+            documents=["historia familiar", "memoria comunitaria", "family history"],
+            metadatas=[
+                {"source": "a.txt", "language": "es"},
+                {"source": "b.txt", "language": "es"},
+                {"source": "c.txt", "language": "en"},
+            ],
+        )
+
+        q_vec = embedder.embed(["historia memoria"])[0]
+        result = backend.query(q_vec, k=3, language_filter="es")
+
+        assert set(result["ids"][0]) == {"es-doc-1", "es-doc-2"}
+
     def test_upsert_overwrites(self, embedder, tmp_path, monkeypatch):
         monkeypatch.setenv("CHROMA_PATH", str(tmp_path / "chroma"))
         monkeypatch.setenv("CHROMA_COLLECTION", "test_col")

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -52,6 +52,28 @@ class TestChromaBackend:
         assert len(result["ids"]) == 1  # ChromaDB wraps in outer list
         assert len(result["ids"][0]) == 2
 
+    def test_query_filters_by_language(self, embedder, tmp_path, monkeypatch):
+        monkeypatch.setenv("CHROMA_PATH", str(tmp_path / "chroma"))
+        monkeypatch.setenv("CHROMA_COLLECTION", "test_col")
+        from alcove.index.backend import ChromaBackend
+
+        backend = ChromaBackend(embedder)
+        vecs = embedder.embed(["family history", "historia familiar"])
+        backend.add(
+            ids=["en-doc", "es-doc"],
+            embeddings=vecs,
+            documents=["family history", "historia familiar"],
+            metadatas=[
+                {"source": "a.txt", "language": "en"},
+                {"source": "b.txt", "language": "es"},
+            ],
+        )
+
+        q_vec = embedder.embed(["historia"])[0]
+        result = backend.query(q_vec, k=2, language_filter="es")
+
+        assert result["ids"] == [["es-doc"]]
+
     def test_upsert_overwrites(self, embedder, tmp_path, monkeypatch):
         monkeypatch.setenv("CHROMA_PATH", str(tmp_path / "chroma"))
         monkeypatch.setenv("CHROMA_COLLECTION", "test_col")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -129,20 +129,39 @@ def test_invalid_numeric_env_uses_defaults(monkeypatch):
     monkeypatch.delenv("ALCOVE_CONFIG_PATH", raising=False)
     monkeypatch.setenv("ALCOVE_RECENT_ACTIVITY_LIMIT", "many")
     monkeypatch.setenv("ALCOVE_EXCERPT_CHARS", "wide")
+    monkeypatch.setenv("ALCOVE_LANGUAGE_CONFIDENCE_THRESHOLD", "maybe")
+    monkeypatch.setenv("ALCOVE_LANGUAGE_TIMEOUT", "later")
 
     cfg = load_config()
     assert cfg.recent_activity_limit == 5
     assert cfg.excerpt_chars is None
+    assert cfg.language.confidence_threshold == 0.0
+    assert cfg.language.timeout == 30.0
 
 
 def test_numeric_env_clamps_to_minimum(monkeypatch):
     monkeypatch.delenv("ALCOVE_CONFIG_PATH", raising=False)
     monkeypatch.setenv("ALCOVE_RECENT_ACTIVITY_LIMIT", "0")
     monkeypatch.setenv("ALCOVE_EXCERPT_CHARS", "-100")
+    monkeypatch.setenv("ALCOVE_LANGUAGE_CONFIDENCE_THRESHOLD", "2")
+    monkeypatch.setenv("ALCOVE_LANGUAGE_TIMEOUT", "0")
 
     cfg = load_config()
     assert cfg.recent_activity_limit == 1
     assert cfg.excerpt_chars == 1
+    assert cfg.language.confidence_threshold == 1.0
+    assert cfg.language.timeout == 0.1
+
+
+def test_float_config_values_can_be_booleans(tmp_path, monkeypatch):
+    config_file = tmp_path / "alcove.json"
+    config_file.write_text(
+        json.dumps({"language": {"confidence_threshold": True}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(config_file))
+
+    assert load_config().language.confidence_threshold == 1.0
 
 
 def test_toml_feature_flags(tmp_path, monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,15 @@ import json
 
 import pytest
 
-from alcove.config import Deployment, Features, Path as ConfigPath, RuntimeConfig, load_config, set_private_mode
+from alcove.config import (
+    Deployment,
+    Features,
+    Language,
+    Path as ConfigPath,
+    RuntimeConfig,
+    load_config,
+    set_private_mode,
+)
 
 
 def test_default_features_are_conservative():
@@ -24,6 +32,15 @@ def test_default_deployment_identity():
     deployment = Deployment()
     assert deployment.mode == "local"
     assert deployment.instance_name == "Alcove"
+
+
+def test_default_language_config_is_local_heuristic():
+    language = Language()
+    assert language.provider == "heuristic"
+    assert language.model is None
+    assert language.confidence_threshold == 0.0
+    assert language.ollama_base_url == "http://127.0.0.1:11434"
+    assert language.timeout == 30.0
 
 
 def test_default_private_mode_is_true(monkeypatch):
@@ -65,6 +82,30 @@ def test_env_deployment_overrides(monkeypatch):
     cfg = load_config()
     assert cfg.deployment.mode == "demo"
     assert cfg.deployment.instance_name == "Community Archive"
+
+
+def test_env_language_overrides(monkeypatch):
+    monkeypatch.delenv("ALCOVE_CONFIG_PATH", raising=False)
+    monkeypatch.setenv("ALCOVE_LANGUAGE_PROVIDER", "transformers")
+    monkeypatch.setenv("ALCOVE_LANGUAGE_MODEL", "local-language-id")
+    monkeypatch.setenv("ALCOVE_LANGUAGE_CONFIDENCE_THRESHOLD", "0.8")
+    monkeypatch.setenv("ALCOVE_LANGUAGE_OLLAMA_BASE_URL", "http://localhost:11435")
+    monkeypatch.setenv("ALCOVE_LANGUAGE_TIMEOUT", "12.5")
+
+    cfg = load_config()
+
+    assert cfg.language.provider == "transformers"
+    assert cfg.language.model == "local-language-id"
+    assert cfg.language.confidence_threshold == 0.8
+    assert cfg.language.ollama_base_url == "http://localhost:11435"
+    assert cfg.language.timeout == 12.5
+
+
+def test_custom_language_provider_name_is_preserved(monkeypatch):
+    monkeypatch.delenv("ALCOVE_CONFIG_PATH", raising=False)
+    monkeypatch.setenv("ALCOVE_LANGUAGE_PROVIDER", "custom-lang")
+
+    assert load_config().language.provider == "custom-lang"
 
 
 def test_invalid_deployment_mode_falls_back(monkeypatch):
@@ -116,7 +157,13 @@ def test_toml_feature_flags(tmp_path, monkeypatch):
         "recent_activity_limit = 9\n"
         "[deployment]\n"
         'mode = "hosted"\n'
-        'instance_name = "My Archive"\n',
+        'instance_name = "My Archive"\n'
+        "[language]\n"
+        'provider = "ollama"\n'
+        'model = "llama3.2"\n'
+        'confidence_threshold = 0.6\n'
+        'ollama_base_url = "http://localhost:11435"\n'
+        'timeout = 15.5\n',
         encoding="utf-8",
     )
     monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(toml))
@@ -129,6 +176,11 @@ def test_toml_feature_flags(tmp_path, monkeypatch):
         "ALCOVE_RECENT_ACTIVITY_LIMIT",
         "ALCOVE_EXCERPT_CHARS",
         "ALCOVE_PRIVATE",
+        "ALCOVE_LANGUAGE_PROVIDER",
+        "ALCOVE_LANGUAGE_MODEL",
+        "ALCOVE_LANGUAGE_CONFIDENCE_THRESHOLD",
+        "ALCOVE_LANGUAGE_OLLAMA_BASE_URL",
+        "ALCOVE_LANGUAGE_TIMEOUT",
     ):
         monkeypatch.delenv(env_name, raising=False)
 
@@ -139,6 +191,11 @@ def test_toml_feature_flags(tmp_path, monkeypatch):
     assert cfg.recent_activity_limit == 9
     assert cfg.deployment.mode == "hosted"
     assert cfg.deployment.instance_name == "My Archive"
+    assert cfg.language.provider == "ollama"
+    assert cfg.language.model == "llama3.2"
+    assert cfg.language.confidence_threshold == 0.6
+    assert cfg.language.ollama_base_url == "http://localhost:11435"
+    assert cfg.language.timeout == 15.5
     assert cfg.excerpt_chars == 250
     assert cfg.private_mode is False
 
@@ -179,6 +236,10 @@ def test_json_feature_flags(tmp_path, monkeypatch):
             {
                 "features": {"uploads": False, "turnstile": True},
                 "deployment": {"mode": "hosted", "instance_name": "Demo Archive"},
+                "language": {
+                    "provider": "langdetect",
+                    "confidence_threshold": 0.7,
+                },
                 "excerpt_chars": 120,
                 "private_mode": False,
             }
@@ -192,6 +253,8 @@ def test_json_feature_flags(tmp_path, monkeypatch):
     assert cfg.features.turnstile is True
     assert cfg.deployment.mode == "hosted"
     assert cfg.deployment.instance_name == "Demo Archive"
+    assert cfg.language.provider == "langdetect"
+    assert cfg.language.confidence_threshold == 0.7
     assert cfg.excerpt_chars == 120
     assert cfg.private_mode is False
 
@@ -225,6 +288,8 @@ def test_config_objects_are_frozen(monkeypatch):
         cfg.features.uploads = False  # type: ignore[misc]
     with pytest.raises((AttributeError, TypeError)):
         cfg.deployment.mode = "hosted"  # type: ignore[misc]
+    with pytest.raises((AttributeError, TypeError)):
+        cfg.language.provider = "none"  # type: ignore[misc]
 
 
 def test_set_private_mode_creates_toml_when_file_missing(tmp_path, monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,6 +41,7 @@ def test_default_language_config_is_local_heuristic():
     assert language.confidence_threshold == 0.0
     assert language.ollama_base_url == "http://127.0.0.1:11434"
     assert language.timeout == 30.0
+    assert language.max_chars == 4000
 
 
 def test_default_private_mode_is_true(monkeypatch):
@@ -91,6 +92,7 @@ def test_env_language_overrides(monkeypatch):
     monkeypatch.setenv("ALCOVE_LANGUAGE_CONFIDENCE_THRESHOLD", "0.8")
     monkeypatch.setenv("ALCOVE_LANGUAGE_OLLAMA_BASE_URL", "http://localhost:11435")
     monkeypatch.setenv("ALCOVE_LANGUAGE_TIMEOUT", "12.5")
+    monkeypatch.setenv("ALCOVE_LANGUAGE_MAX_CHARS", "500")
 
     cfg = load_config()
 
@@ -99,6 +101,7 @@ def test_env_language_overrides(monkeypatch):
     assert cfg.language.confidence_threshold == 0.8
     assert cfg.language.ollama_base_url == "http://localhost:11435"
     assert cfg.language.timeout == 12.5
+    assert cfg.language.max_chars == 500
 
 
 def test_custom_language_provider_name_is_preserved(monkeypatch):
@@ -131,12 +134,14 @@ def test_invalid_numeric_env_uses_defaults(monkeypatch):
     monkeypatch.setenv("ALCOVE_EXCERPT_CHARS", "wide")
     monkeypatch.setenv("ALCOVE_LANGUAGE_CONFIDENCE_THRESHOLD", "maybe")
     monkeypatch.setenv("ALCOVE_LANGUAGE_TIMEOUT", "later")
+    monkeypatch.setenv("ALCOVE_LANGUAGE_MAX_CHARS", "wide")
 
     cfg = load_config()
     assert cfg.recent_activity_limit == 5
     assert cfg.excerpt_chars is None
     assert cfg.language.confidence_threshold == 0.0
     assert cfg.language.timeout == 30.0
+    assert cfg.language.max_chars == 4000
 
 
 def test_numeric_env_clamps_to_minimum(monkeypatch):
@@ -145,12 +150,14 @@ def test_numeric_env_clamps_to_minimum(monkeypatch):
     monkeypatch.setenv("ALCOVE_EXCERPT_CHARS", "-100")
     monkeypatch.setenv("ALCOVE_LANGUAGE_CONFIDENCE_THRESHOLD", "2")
     monkeypatch.setenv("ALCOVE_LANGUAGE_TIMEOUT", "0")
+    monkeypatch.setenv("ALCOVE_LANGUAGE_MAX_CHARS", "0")
 
     cfg = load_config()
     assert cfg.recent_activity_limit == 1
     assert cfg.excerpt_chars == 1
     assert cfg.language.confidence_threshold == 1.0
     assert cfg.language.timeout == 0.1
+    assert cfg.language.max_chars == 1
 
 
 def test_float_config_values_can_be_booleans(tmp_path, monkeypatch):
@@ -182,7 +189,8 @@ def test_toml_feature_flags(tmp_path, monkeypatch):
         'model = "llama3.2"\n'
         'confidence_threshold = 0.6\n'
         'ollama_base_url = "http://localhost:11435"\n'
-        'timeout = 15.5\n',
+        'timeout = 15.5\n'
+        'max_chars = 250\n',
         encoding="utf-8",
     )
     monkeypatch.setenv("ALCOVE_CONFIG_PATH", str(toml))
@@ -200,6 +208,7 @@ def test_toml_feature_flags(tmp_path, monkeypatch):
         "ALCOVE_LANGUAGE_CONFIDENCE_THRESHOLD",
         "ALCOVE_LANGUAGE_OLLAMA_BASE_URL",
         "ALCOVE_LANGUAGE_TIMEOUT",
+        "ALCOVE_LANGUAGE_MAX_CHARS",
     ):
         monkeypatch.delenv(env_name, raising=False)
 
@@ -215,6 +224,7 @@ def test_toml_feature_flags(tmp_path, monkeypatch):
     assert cfg.language.confidence_threshold == 0.6
     assert cfg.language.ollama_base_url == "http://localhost:11435"
     assert cfg.language.timeout == 15.5
+    assert cfg.language.max_chars == 250
     assert cfg.excerpt_chars == 250
     assert cfg.private_mode is False
 
@@ -258,6 +268,7 @@ def test_json_feature_flags(tmp_path, monkeypatch):
                 "language": {
                     "provider": "langdetect",
                     "confidence_threshold": 0.7,
+                    "max_chars": 600,
                 },
                 "excerpt_chars": 120,
                 "private_mode": False,
@@ -274,6 +285,7 @@ def test_json_feature_flags(tmp_path, monkeypatch):
     assert cfg.deployment.instance_name == "Demo Archive"
     assert cfg.language.provider == "langdetect"
     assert cfg.language.confidence_threshold == 0.7
+    assert cfg.language.max_chars == 600
     assert cfg.excerpt_chars == 120
     assert cfg.private_mode is False
 

--- a/tests/test_keyword.py
+++ b/tests/test_keyword.py
@@ -140,7 +140,7 @@ class TestHybridMerge:
         )
         monkeypatch.setattr(
             "alcove.query.retriever.query_keyword",
-            lambda q, n_results=3: kw_result,
+            lambda q, n_results=3, collections=None: kw_result,
         )
 
         from alcove.query.retriever import query_hybrid

--- a/tests/test_language_metadata.py
+++ b/tests/test_language_metadata.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+
+from fastapi.testclient import TestClient
+
+from alcove.index.language import detect_language
+from alcove.query import api
+from alcove.query.retriever import query_text
+
+
+class _FakeEmbedder:
+    def embed(self, texts):
+        return [[0.1, 0.2, 0.3] for _ in texts]
+
+
+class _CaptureBackend:
+    def __init__(self):
+        self.add_calls = []
+        self.query_calls = []
+
+    def add(self, ids, embeddings, documents, metadatas):
+        self.add_calls.append({
+            "ids": ids,
+            "embeddings": embeddings,
+            "documents": documents,
+            "metadatas": metadatas,
+        })
+
+    def query(self, embedding, k=3, collections=None, language_filter=None):
+        self.query_calls.append({
+            "embedding": embedding,
+            "k": k,
+            "collections": collections,
+            "language_filter": language_filter,
+        })
+        return {"ids": [[]], "documents": [[]], "distances": [[]], "metadatas": [[]]}
+
+
+def test_detect_language_empty_returns_unknown():
+    assert detect_language("") == "unknown"
+
+
+def test_detect_language_english_returns_en():
+    text = "The harbor interviews describe family history, migration, and faith traditions in detail."
+    assert detect_language(text) == "en"
+
+
+def test_detect_language_spanish_returns_es():
+    text = "Las entrevistas familiares describen historia, migracion, tradiciones y memoria colectiva."
+    assert detect_language(text) == "es"
+
+
+def test_index_pipeline_writes_language_metadata(tmp_path, monkeypatch):
+    from alcove.index import pipeline
+
+    chunks_file = tmp_path / "chunks.jsonl"
+    rows = [
+        {
+            "id": "a:0",
+            "source": "english.txt",
+            "chunk": "The interview transcript discusses work, family, and local history in Minnesota.",
+        },
+        {
+            "id": "b:0",
+            "source": "spanish.txt",
+            "chunk": "La entrevista habla de trabajo, familia y memoria cultural en la comunidad.",
+        },
+    ]
+    chunks_file.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+
+    backend = _CaptureBackend()
+    monkeypatch.setattr(pipeline, "get_embedder", lambda: _FakeEmbedder())
+    monkeypatch.setattr(pipeline, "get_backend", lambda _embedder: backend)
+
+    total = pipeline.run(chunks_file=str(chunks_file))
+
+    assert total == 2
+    metadatas = backend.add_calls[0]["metadatas"]
+    assert [meta["source"] for meta in metadatas] == ["english.txt", "spanish.txt"]
+    assert [meta["language"] for meta in metadatas] == ["en", "es"]
+
+
+def test_retriever_passes_language_filter(monkeypatch):
+    from alcove.query import retriever
+
+    backend = _CaptureBackend()
+    monkeypatch.setattr(retriever, "get_embedder", lambda: _FakeEmbedder())
+    monkeypatch.setattr(retriever, "get_backend", lambda _embedder: backend)
+
+    result = query_text("hola mundo", n_results=4, language_filter="es")
+
+    assert result["ids"] == [[]]
+    assert backend.query_calls[0]["k"] == 4
+    assert backend.query_calls[0]["language_filter"] == "es"
+
+
+def test_api_query_accepts_language_filter(monkeypatch):
+    called = {}
+
+    def fake_query_text(query, n_results=3, language_filter=None, **kwargs):
+        called["query"] = query
+        called["k"] = n_results
+        called["language_filter"] = language_filter
+        called["collections"] = kwargs.get("collections")
+        return {"ids": [[]], "documents": [[]], "distances": [[]], "metadatas": [[]]}
+
+    monkeypatch.setattr(api, "query_text", fake_query_text)
+
+    client = TestClient(api.app)
+    response = client.post("/query", json={"query": "hola", "k": 2, "language_filter": "es"})
+
+    assert response.status_code == 200
+    assert called == {"query": "hola", "k": 2, "language_filter": "es", "collections": None}
+
+
+def test_keyword_search_can_filter_by_language(tmp_path):
+    from alcove.index.keyword import KeywordIndex
+
+    chunks_file = tmp_path / "chunks.jsonl"
+    rows = [
+        {
+            "id": "en:0",
+            "source": "english.txt",
+            "chunk": "The family interview covers community history.",
+        },
+        {
+            "id": "es:0",
+            "source": "spanish.txt",
+            "chunk": "La entrevista familiar cubre historia de la comunidad.",
+        },
+    ]
+    chunks_file.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+
+    result = KeywordIndex(str(chunks_file)).search("historia comunidad", k=3, language_filter="es")
+
+    assert result["ids"] == [["es:0"]]
+    assert result["metadatas"][0][0]["language"] == "es"

--- a/tests/test_language_metadata.py
+++ b/tests/test_language_metadata.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sys
 import types
+import urllib.error
 
 import pytest
 from fastapi.testclient import TestClient
@@ -177,6 +178,60 @@ def test_langdetect_provider_returns_unknown_on_low_confidence(monkeypatch):
     assert detector.detect("La familia").language == "unknown"
 
 
+def test_langdetect_provider_handles_empty_and_no_candidates(monkeypatch):
+    fake_module = types.ModuleType("langdetect")
+
+    class FakeDetectorFactory:
+        seed = None
+
+    class FakeLangDetectException(Exception):
+        pass
+
+    fake_module.DetectorFactory = FakeDetectorFactory
+    fake_module.LangDetectException = FakeLangDetectException
+    fake_module.detect_langs = lambda sample: []
+    monkeypatch.setitem(sys.modules, "langdetect", fake_module)
+
+    detector = LangdetectLanguageDetector()
+
+    assert detector.detect("").language == "unknown"
+    assert detector.detect("???").language == "unknown"
+
+
+def test_langdetect_provider_handles_detection_exception(monkeypatch):
+    fake_module = types.ModuleType("langdetect")
+
+    class FakeDetectorFactory:
+        seed = None
+
+    class FakeLangDetectException(Exception):
+        pass
+
+    def fail_detect(sample):
+        raise FakeLangDetectException("not enough text")
+
+    fake_module.DetectorFactory = FakeDetectorFactory
+    fake_module.LangDetectException = FakeLangDetectException
+    fake_module.detect_langs = fail_detect
+    monkeypatch.setitem(sys.modules, "langdetect", fake_module)
+
+    assert LangdetectLanguageDetector().detect("???").language == "unknown"
+
+
+def test_langdetect_provider_reports_missing_dependency(monkeypatch):
+    original_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "langdetect":
+            raise ImportError("missing")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+    with pytest.raises(RuntimeError, match="langdetect"):
+        LangdetectLanguageDetector().detect("The family history interview")
+
+
 def test_transformers_provider_uses_configured_model(monkeypatch):
     fake_module = types.ModuleType("transformers")
     calls = {}
@@ -204,6 +259,35 @@ def test_transformers_provider_uses_configured_model(monkeypatch):
         "sample": "La familia",
         "truncation": True,
     }
+
+
+def test_transformers_provider_handles_empty_and_low_confidence(monkeypatch):
+    fake_module = types.ModuleType("transformers")
+
+    def fake_pipeline(task, model):
+        return lambda sample, truncation=True: [{"label": "es", "score": 0.2}]
+
+    fake_module.pipeline = fake_pipeline
+    monkeypatch.setitem(sys.modules, "transformers", fake_module)
+
+    detector = TransformersLanguageDetector(confidence_threshold=0.8)
+
+    assert detector.detect("").language == "unknown"
+    assert detector.detect("La familia").language == "unknown"
+
+
+def test_transformers_provider_reports_missing_dependency(monkeypatch):
+    original_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "transformers":
+            raise ImportError("missing")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+    with pytest.raises(RuntimeError, match="transformers"):
+        TransformersLanguageDetector()
 
 
 def test_ollama_provider_reads_json_language_response(monkeypatch):
@@ -240,6 +324,10 @@ def test_ollama_provider_reads_json_language_response(monkeypatch):
     assert calls["body"]["format"] == "json"
 
 
+def test_ollama_provider_handles_empty_text():
+    assert OllamaLanguageDetector().detect("").language == "unknown"
+
+
 def test_ollama_provider_returns_unknown_for_unparseable_response(monkeypatch):
     class FakeResponse:
         def __enter__(self):
@@ -259,6 +347,81 @@ def test_ollama_provider_returns_unknown_for_unparseable_response(monkeypatch):
     detector = OllamaLanguageDetector()
 
     assert detector.detect("Bonjour la famille").language == "unknown"
+
+
+def test_ollama_provider_reports_http_and_url_errors(monkeypatch):
+    def raise_http(request, timeout):
+        raise urllib.error.HTTPError(
+            request.full_url,
+            500,
+            "server error",
+            hdrs=None,
+            fp=None,
+        )
+
+    monkeypatch.setattr("alcove.index.language.urllib.request.urlopen", raise_http)
+    detector = OllamaLanguageDetector(base_url="http://127.0.0.1:11434")
+
+    with pytest.raises(RuntimeError, match="HTTP 500"):
+        detector.detect("Bonjour")
+
+    def raise_url(request, timeout):
+        raise urllib.error.URLError("offline")
+
+    monkeypatch.setattr("alcove.index.language.urllib.request.urlopen", raise_url)
+
+    with pytest.raises(RuntimeError, match="Could not reach Ollama"):
+        detector.detect("Bonjour")
+
+
+def test_invalid_confidence_env_falls_back(monkeypatch):
+    monkeypatch.setenv("ALCOVE_LANGUAGE_CONFIDENCE_THRESHOLD", "wide")
+
+    detector = LangdetectLanguageDetector()
+
+    assert detector.confidence_threshold == 0.0
+
+
+def test_get_language_detector_rejects_unknown_provider(monkeypatch):
+    monkeypatch.setenv("ALCOVE_LANGUAGE_PROVIDER", "does-not-exist")
+
+    with pytest.raises(ValueError, match="Unknown language detector"):
+        get_language_detector()
+
+
+def test_get_language_detector_configures_transformers_provider(monkeypatch):
+    fake_module = types.ModuleType("transformers")
+    calls = {}
+
+    def fake_pipeline(task, model):
+        calls["task"] = task
+        calls["model"] = model
+        return lambda sample, truncation=True: [{"label": "en", "score": 1.0}]
+
+    fake_module.pipeline = fake_pipeline
+    monkeypatch.setitem(sys.modules, "transformers", fake_module)
+    monkeypatch.setenv("ALCOVE_LANGUAGE_PROVIDER", "huggingface")
+    monkeypatch.setenv("ALCOVE_LANGUAGE_MODEL", "local-detector")
+    monkeypatch.setenv("ALCOVE_LANGUAGE_CONFIDENCE_THRESHOLD", "0.5")
+
+    detector = get_language_detector()
+
+    assert detector.model_name == "local-detector"
+    assert detector.confidence_threshold == 0.5
+    assert calls == {"task": "text-classification", "model": "local-detector"}
+
+
+def test_get_language_detector_configures_ollama_provider(monkeypatch):
+    monkeypatch.setenv("ALCOVE_LANGUAGE_PROVIDER", "ollama")
+    monkeypatch.setenv("ALCOVE_LANGUAGE_MODEL", "llama3.2")
+    monkeypatch.setenv("ALCOVE_LANGUAGE_OLLAMA_BASE_URL", "http://localhost:11435")
+    monkeypatch.setenv("ALCOVE_LANGUAGE_TIMEOUT", "7")
+
+    detector = get_language_detector()
+
+    assert detector.model_name == "llama3.2"
+    assert detector.base_url == "http://localhost:11435"
+    assert detector.timeout == 7
 
 
 def test_plugin_language_detector_can_be_selected(monkeypatch):
@@ -725,6 +888,22 @@ def test_zvec_query_filters_by_language_and_returns_metadata():
 
     assert result["ids"] == [["doc-2"]]
     assert result["metadatas"][0][0]["language"] == "es"
+
+
+def test_zvec_query_filters_by_collection():
+    from alcove.index.backend import ZvecBackend
+
+    backend = ZvecBackend.__new__(ZvecBackend)
+    backend._zvec = _FakeZvec
+    backend._collection = _FakeZvecCollection([
+        _FakeZvecDoc(document="hello", source="a.txt", collection="letters", language="en"),
+        _FakeZvecDoc(doc_id="doc-2", document="hola", source="b.txt", collection="minutes", language="es"),
+    ])
+
+    result = backend.query([0.1], k=1, collections=["minutes"])
+
+    assert result["ids"] == [["doc-2"]]
+    assert result["metadatas"][0][0]["collection"] == "minutes"
 
 
 def test_zvec_query_handles_old_schema_without_language():

--- a/tests/test_language_metadata.py
+++ b/tests/test_language_metadata.py
@@ -118,6 +118,12 @@ def test_detect_language_handles_invalid_sample_limit(monkeypatch):
     assert detect_language("The family history interview") == "en"
 
 
+def test_detect_language_uses_configured_sample_limit(monkeypatch):
+    monkeypatch.setenv("ALCOVE_LANGUAGE_MAX_CHARS", "6")
+
+    assert detect_language("qwerty The family history interview") == "unknown"
+
+
 def test_get_language_detector_can_disable_detection(monkeypatch):
     monkeypatch.setenv("ALCOVE_LANGUAGE_PROVIDER", "none")
 
@@ -326,6 +332,31 @@ def test_ollama_provider_reads_json_language_response(monkeypatch):
     assert calls["body"]["format"] == "json"
 
 
+def test_ollama_provider_limits_sample_text(monkeypatch):
+    calls = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps({"response": json.dumps({"language": "fr"})}).encode("utf-8")
+
+    def fake_urlopen(request, timeout):
+        calls["body"] = json.loads(request.data.decode("utf-8"))
+        return FakeResponse()
+
+    monkeypatch.setattr("alcove.index.language.urllib.request.urlopen", fake_urlopen)
+
+    detector = OllamaLanguageDetector(max_chars=7)
+    detector.detect("Bonjour la famille")
+
+    assert calls["body"]["prompt"].endswith("Bonjour")
+
+
 def test_ollama_provider_handles_empty_text():
     assert OllamaLanguageDetector().detect("").language == "unknown"
 
@@ -348,6 +379,40 @@ def test_ollama_provider_returns_unknown_for_unparseable_response(monkeypatch):
 
     detector = OllamaLanguageDetector()
 
+    assert detector.detect("Bonjour la famille").language == "unknown"
+
+
+def test_ollama_provider_returns_unknown_for_malformed_payloads(monkeypatch):
+    class FakeResponse:
+        def __init__(self, body):
+            self.body = body
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return self.body
+
+    monkeypatch.setattr(
+        "alcove.index.language.urllib.request.urlopen",
+        lambda request, timeout: FakeResponse(b"[1, 2, 3]"),
+    )
+    detector = OllamaLanguageDetector()
+    assert detector.detect("Bonjour la famille").language == "unknown"
+
+    monkeypatch.setattr(
+        "alcove.index.language.urllib.request.urlopen",
+        lambda request, timeout: FakeResponse(json.dumps({"response": "[1]"}).encode("utf-8")),
+    )
+    assert detector.detect("Bonjour la famille").language == "unknown"
+
+    monkeypatch.setattr(
+        "alcove.index.language.urllib.request.urlopen",
+        lambda request, timeout: FakeResponse(b"\xff"),
+    )
     assert detector.detect("Bonjour la famille").language == "unknown"
 
 
@@ -378,6 +443,15 @@ def test_ollama_provider_preserves_explicit_zero_timeout():
     detector = OllamaLanguageDetector(timeout=0.0)
 
     assert detector.timeout == 0.0
+
+
+def test_ollama_provider_rejects_non_local_base_url():
+    with pytest.raises(ValueError, match="loopback"):
+        OllamaLanguageDetector(base_url="https://example.com")
+    with pytest.raises(ValueError, match="loopback"):
+        OllamaLanguageDetector(base_url="file:///tmp/ollama.sock")
+    with pytest.raises(ValueError, match="loopback"):
+        OllamaLanguageDetector(base_url="http:///missing-host")
 
 
 def test_invalid_confidence_env_falls_back(monkeypatch):
@@ -434,12 +508,14 @@ def test_get_language_detector_configures_ollama_provider(monkeypatch):
     monkeypatch.setenv("ALCOVE_LANGUAGE_MODEL", "llama3.2")
     monkeypatch.setenv("ALCOVE_LANGUAGE_OLLAMA_BASE_URL", "http://localhost:11435")
     monkeypatch.setenv("ALCOVE_LANGUAGE_TIMEOUT", "7")
+    monkeypatch.setenv("ALCOVE_LANGUAGE_MAX_CHARS", "700")
 
     detector = get_language_detector()
 
     assert detector.model_name == "llama3.2"
     assert detector.base_url == "http://localhost:11435"
     assert detector.timeout == 7
+    assert detector.max_chars == 700
 
 
 def test_plugin_language_detector_can_be_selected(monkeypatch):

--- a/tests/test_language_metadata.py
+++ b/tests/test_language_metadata.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import sys
+import types
 
 from fastapi.testclient import TestClient
 
@@ -51,6 +53,62 @@ def test_detect_language_spanish_returns_es():
     assert detect_language(text) == "es"
 
 
+def test_detect_language_script_shortcuts():
+    assert detect_language("История семьи и сообщества") == "ru"
+    assert detect_language("家族历史和社区记忆") == "zh"
+    assert detect_language("تاريخ العائلة والمجتمع") == "ar"
+
+
+def test_detect_language_french_heuristic():
+    text = "L'histoire de la famille décrit la mémoire, le travail et la communauté."
+    assert detect_language(text) == "fr"
+
+
+def test_detect_language_unknown_for_unscored_latin_text():
+    assert detect_language("qwerty zxcv asdf") == "unknown"
+
+
+def test_detect_language_uses_optional_langdetect(monkeypatch):
+    fake_module = types.ModuleType("langdetect")
+
+    class FakeDetectorFactory:
+        seed = None
+
+    class FakeLangDetectException(Exception):
+        pass
+
+    def detect_portuguese(sample):
+        return "pt"
+
+    fake_module.DetectorFactory = FakeDetectorFactory
+    fake_module.LangDetectException = FakeLangDetectException
+    fake_module.detect = detect_portuguese
+    monkeypatch.setitem(sys.modules, "langdetect", fake_module)
+
+    assert detect_language("texto em portugues") == "pt"
+    assert FakeDetectorFactory.seed == 0
+
+
+def test_detect_language_falls_back_on_langdetect_exception(monkeypatch):
+    fake_module = types.ModuleType("langdetect")
+
+    class FakeDetectorFactory:
+        seed = None
+
+    class FakeLangDetectException(Exception):
+        pass
+
+    def fail_detect(sample):
+        raise FakeLangDetectException("not enough text")
+
+    fake_module.DetectorFactory = FakeDetectorFactory
+    fake_module.LangDetectException = FakeLangDetectException
+    fake_module.detect = fail_detect
+    monkeypatch.setitem(sys.modules, "langdetect", fake_module)
+
+    assert detect_language("The family history interview") == "en"
+
+
 def test_index_pipeline_writes_language_metadata(tmp_path, monkeypatch):
     from alcove.index import pipeline
 
@@ -70,8 +128,12 @@ def test_index_pipeline_writes_language_metadata(tmp_path, monkeypatch):
     chunks_file.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
 
     backend = _CaptureBackend()
-    monkeypatch.setattr(pipeline, "get_embedder", lambda: _FakeEmbedder())
-    monkeypatch.setattr(pipeline, "get_backend", lambda _embedder: backend)
+    monkeypatch.setattr(pipeline, "get_embedder", _FakeEmbedder)
+
+    def get_backend(_embedder):
+        return backend
+
+    monkeypatch.setattr(pipeline, "get_backend", get_backend)
 
     total = pipeline.run(chunks_file=str(chunks_file))
 
@@ -85,8 +147,12 @@ def test_retriever_passes_language_filter(monkeypatch):
     from alcove.query import retriever
 
     backend = _CaptureBackend()
-    monkeypatch.setattr(retriever, "get_embedder", lambda: _FakeEmbedder())
-    monkeypatch.setattr(retriever, "get_backend", lambda _embedder: backend)
+    monkeypatch.setattr(retriever, "get_embedder", _FakeEmbedder)
+
+    def get_backend(_embedder):
+        return backend
+
+    monkeypatch.setattr(retriever, "get_backend", get_backend)
 
     result = query_text("hola mundo", n_results=4, language_filter="es")
 
@@ -136,3 +202,179 @@ def test_keyword_search_can_filter_by_language(tmp_path):
 
     assert result["ids"] == [["es:0"]]
     assert result["metadatas"][0][0]["language"] == "es"
+
+
+def test_chroma_query_where_combines_collection_and_language():
+    from alcove.index.backend import _query_where
+
+    assert _query_where() is None
+    assert _query_where(language_filter="ES") == {"language": "es"}
+    assert _query_where(collections=["docs"], language_filter="es") == {
+        "$and": [{"collection": {"$in": ["docs"]}}, {"language": "es"}]
+    }
+
+
+class _FakeChromaCollection:
+    name = "docs"
+
+    def __init__(self):
+        self.query_kwargs = None
+
+    def count(self):
+        return 1
+
+    def query(self, **kwargs):
+        self.query_kwargs = kwargs
+        return {
+            "ids": [["doc-1"]],
+            "documents": [["hola"]],
+            "distances": [[0.1]],
+            "metadatas": [[{"source": "a.txt", "language": "es"}]],
+        }
+
+
+def test_multi_chroma_query_passes_language_filter():
+    from alcove.index.backend import MultiChromaBackend
+
+    collection = _FakeChromaCollection()
+    backend = MultiChromaBackend.__new__(MultiChromaBackend)
+
+    def get_filtered_collections(collections=None):
+        return [collection]
+
+    backend._get_filtered_collections = get_filtered_collections
+
+    result = backend.query([0.1], k=1, language_filter="ES")
+
+    assert result["ids"] == [["doc-1"]]
+    assert collection.query_kwargs["where"] == {"language": "es"}
+
+
+def test_multi_root_query_passes_language_filter():
+    from alcove.index.backend import MultiRootBackend
+
+    collection = _FakeChromaCollection()
+    backend = MultiRootBackend.__new__(MultiRootBackend)
+    backend._cols = [("docs", None, collection)]
+
+    result = backend.query([0.1], k=1, language_filter="es")
+
+    assert result["ids"] == [["doc-1"]]
+    assert collection.query_kwargs["where"] == {"language": "es"}
+
+
+class _FakeZvecDoc:
+    def __init__(self, id="doc-1", score=-0.2, **fields):
+        self.id = id
+        self.score = score
+        self._fields = fields
+
+    def field(self, name):
+        return self._fields.get(name)
+
+
+class _FakeZvec:
+    class DataType:
+        STRING = "string"
+        VECTOR_FP32 = "vector"
+
+    class CollectionOption:
+        pass
+
+    class FieldSchema:
+        def __init__(self, name, data_type):
+            self.name = name
+            self.data_type = data_type
+
+    class VectorSchema:
+        def __init__(self, name, data_type, dimension):
+            self.name = name
+            self.data_type = data_type
+            self.dimension = dimension
+
+    class CollectionSchema:
+        def __init__(self, name, fields, vectors):
+            self.name = name
+            self.fields = fields
+            self.vectors = vectors
+
+    class VectorQuery:
+        def __init__(self, name, vector):
+            self.name = name
+            self.vector = vector
+
+    class Doc:
+        def __init__(self, id, vectors, fields):
+            self.id = id
+            self.vectors = vectors
+            self.fields = fields
+
+
+class _FakeZvecCollection:
+    def __init__(self, docs=None, raise_on_language=False):
+        self.docs = docs or []
+        self.raise_on_language = raise_on_language
+        self.upserted = None
+        self.flushed = False
+
+    def upsert(self, docs):
+        self.upserted = docs
+
+    def flush(self):
+        self.flushed = True
+
+    def query(self, vectors, topk, output_fields):
+        if self.raise_on_language and "language" in output_fields:
+            raise RuntimeError("old schema")
+        return self.docs[:topk]
+
+
+def test_zvec_add_writes_language_metadata():
+    from alcove.index.backend import ZvecBackend
+
+    backend = ZvecBackend.__new__(ZvecBackend)
+    backend._zvec = _FakeZvec
+    backend._collection = _FakeZvecCollection()
+
+    backend.add(
+        ids=["doc-1"],
+        embeddings=[[0.1]],
+        documents=["hola"],
+        metadatas=[{"source": "a.txt", "collection": "docs", "language": "ES"}],
+    )
+
+    doc = backend._collection.upserted[0]
+    assert doc.fields["language"] == "es"
+    assert backend._collection.flushed is True
+
+
+def test_zvec_query_filters_by_language_and_returns_metadata():
+    from alcove.index.backend import ZvecBackend
+
+    backend = ZvecBackend.__new__(ZvecBackend)
+    backend._zvec = _FakeZvec
+    backend._collection = _FakeZvecCollection([
+        _FakeZvecDoc(document="hello", source="a.txt", collection="docs", language="en"),
+        _FakeZvecDoc(id="doc-2", document="hola", source="b.txt", collection="docs", language="es"),
+    ])
+
+    result = backend.query([0.1], k=1, language_filter="es")
+
+    assert result["ids"] == [["doc-2"]]
+    assert result["metadatas"][0][0]["language"] == "es"
+
+
+def test_zvec_query_handles_old_schema_without_language():
+    from alcove.index.backend import ZvecBackend
+
+    backend = ZvecBackend.__new__(ZvecBackend)
+    backend._zvec = _FakeZvec
+    backend._collection = _FakeZvecCollection(
+        [_FakeZvecDoc(document="hello", source="a.txt", collection="docs")],
+        raise_on_language=True,
+    )
+
+    result = backend.query([0.1], k=1)
+
+    assert result["ids"] == [["doc-1"]]
+    assert result["metadatas"][0][0]["language"] == "unknown"

--- a/tests/test_language_metadata.py
+++ b/tests/test_language_metadata.py
@@ -407,8 +407,8 @@ def test_multi_root_query_passes_language_filter():
 
 
 class _FakeZvecDoc:
-    def __init__(self, id="doc-1", score=-0.2, **fields):
-        self.id = id
+    def __init__(self, doc_id="doc-1", score=-0.2, **fields):
+        self.id = doc_id
         self.score = score
         self._fields = fields
 
@@ -447,8 +447,10 @@ class _FakeZvec:
             self.vector = vector
 
     class Doc:
-        def __init__(self, id, vectors, fields):
-            self.id = id
+        def __init__(self, doc_id=None, vectors=None, fields=None, **kwargs):
+            if doc_id is None:
+                doc_id = kwargs["id"]
+            self.id = doc_id
             self.vectors = vectors
             self.fields = fields
 
@@ -498,7 +500,7 @@ def test_zvec_query_filters_by_language_and_returns_metadata():
     backend._zvec = _FakeZvec
     backend._collection = _FakeZvecCollection([
         _FakeZvecDoc(document="hello", source="a.txt", collection="docs", language="en"),
-        _FakeZvecDoc(id="doc-2", document="hola", source="b.txt", collection="docs", language="es"),
+        _FakeZvecDoc(doc_id="doc-2", document="hola", source="b.txt", collection="docs", language="es"),
     ])
 
     result = backend.query([0.1], k=1, language_filter="es")

--- a/tests/test_language_metadata.py
+++ b/tests/test_language_metadata.py
@@ -59,6 +59,15 @@ def test_detect_language_script_shortcuts():
     assert detect_language("تاريخ العائلة والمجتمع") == "ar"
 
 
+def test_detect_language_accent_shortcuts():
+    assert detect_language("niñez") == "es"
+    assert detect_language("garçon") == "fr"
+
+
+def test_detect_language_unknown_without_tokens():
+    assert detect_language("12345 !!!") == "unknown"
+
+
 def test_detect_language_french_heuristic():
     text = "L'histoire de la famille décrit la mémoire, le travail et la communauté."
     assert detect_language(text) == "fr"
@@ -202,6 +211,140 @@ def test_keyword_search_can_filter_by_language(tmp_path):
 
     assert result["ids"] == [["es:0"]]
     assert result["metadatas"][0][0]["language"] == "es"
+
+
+def test_keyword_search_can_filter_by_collection_after_scoring(tmp_path):
+    from alcove.index.keyword import KeywordIndex
+
+    chunks_file = tmp_path / "chunks.jsonl"
+    rows = [
+        {
+            "id": "letters:0",
+            "source": "letters.txt",
+            "collection": "letters",
+            "chunk": "The family interview covers community history.",
+        },
+        {
+            "id": "minutes:0",
+            "source": "minutes.txt",
+            "collection": "minutes",
+            "chunk": "The family interview covers community history.",
+        },
+    ]
+    chunks_file.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+
+    result = KeywordIndex(str(chunks_file)).search(
+        "family community",
+        k=1,
+        collections=["minutes"],
+    )
+
+    assert result["ids"] == [["minutes:0"]]
+    assert result["metadatas"][0][0]["collection"] == "minutes"
+
+
+def test_api_dispatch_keyword_passes_collection_and_language(monkeypatch):
+    called = {}
+
+    def fake_query_keyword(query, **kwargs):
+        called["query"] = query
+        called.update(kwargs)
+        return {"ids": [[]], "documents": [[]], "distances": [[]], "metadatas": [[]]}
+
+    monkeypatch.setattr(api, "query_keyword", fake_query_keyword)
+
+    result = api._dispatch_query(
+        "familia",
+        4,
+        mode="keyword",
+        collections=["letters"],
+        language_filter="es",
+    )
+
+    assert result["ids"] == [[]]
+    assert called == {
+        "query": "familia",
+        "n_results": 4,
+        "collections": ["letters"],
+        "language_filter": "es",
+    }
+
+
+def test_api_dispatch_hybrid_passes_language(monkeypatch):
+    called = {}
+
+    def fake_query_hybrid(query, **kwargs):
+        called["query"] = query
+        called.update(kwargs)
+        return {"ids": [[]], "documents": [[]], "distances": [[]], "metadatas": [[]]}
+
+    monkeypatch.setattr(api, "query_hybrid", fake_query_hybrid)
+
+    result = api._dispatch_query("familia", 2, mode="hybrid", language_filter="es")
+
+    assert result["ids"] == [[]]
+    assert called == {
+        "query": "familia",
+        "n_results": 2,
+        "collections": None,
+        "language_filter": "es",
+    }
+
+
+def test_hybrid_query_passes_collection_and_language(monkeypatch):
+    from alcove.query import retriever
+
+    calls = []
+
+    def fake_query_text(query, **kwargs):
+        calls.append(("semantic", query, kwargs))
+        return {
+            "ids": [["doc-1"]],
+            "documents": [["semantic"]],
+            "distances": [[0.2]],
+            "metadatas": [[{"source": "a.txt"}]],
+        }
+
+    def fake_query_keyword(query, **kwargs):
+        calls.append(("keyword", query, kwargs))
+        return {
+            "ids": [["doc-1"]],
+            "documents": [["keyword"]],
+            "distances": [[0.4]],
+            "metadatas": [[{"source": "a.txt"}]],
+        }
+
+    monkeypatch.setattr(retriever, "query_text", fake_query_text)
+    monkeypatch.setattr(retriever, "query_keyword", fake_query_keyword)
+
+    result = retriever.query_hybrid(
+        "familia",
+        n_results=3,
+        collections=["letters"],
+        language_filter="es",
+    )
+
+    assert result["ids"] == [["doc-1"]]
+    assert calls == [
+        (
+            "semantic",
+            "familia",
+            {
+                "n_results": 3,
+                "collections": ["letters"],
+                "language_filter": "es",
+            },
+        ),
+        (
+            "keyword",
+            "familia",
+            {
+                "n_results": 3,
+                "collections": ["letters"],
+                "language_filter": "es",
+            },
+        ),
+    ]
 
 
 def test_chroma_query_where_combines_collection_and_language():

--- a/tests/test_language_metadata.py
+++ b/tests/test_language_metadata.py
@@ -4,11 +4,33 @@ import json
 import sys
 import types
 
+import pytest
 from fastapi.testclient import TestClient
 
-from alcove.index.language import detect_language
+from alcove.index.language import (
+    LanguageDetection,
+    LangdetectLanguageDetector,
+    OllamaLanguageDetector,
+    TransformersLanguageDetector,
+    detect_language,
+    get_language_detector,
+)
 from alcove.query import api
 from alcove.query.retriever import query_text
+
+
+@pytest.fixture(autouse=True)
+def clear_language_config(monkeypatch):
+    for env_name in (
+        "ALCOVE_CONFIG_PATH",
+        "ALCOVE_LANGUAGE_PROVIDER",
+        "ALCOVE_LANGUAGE_MODEL",
+        "ALCOVE_LANGUAGE_CONFIDENCE_THRESHOLD",
+        "ALCOVE_LANGUAGE_OLLAMA_BASE_URL",
+        "ALCOVE_LANGUAGE_TIMEOUT",
+        "ALCOVE_LANGUAGE_MAX_CHARS",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
 
 
 class _FakeEmbedder:
@@ -37,6 +59,18 @@ class _CaptureBackend:
             "language_filter": language_filter,
         })
         return {"ids": [[]], "documents": [[]], "distances": [[]], "metadatas": [[]]}
+
+
+class _FakeLanguageDetector:
+    provider = "fake"
+
+    def __init__(self):
+        self.seen = []
+
+    def detect(self, text):
+        self.seen.append(text)
+        language = "es" if "La entrevista" in text else "en"
+        return LanguageDetection(language, 1.0, self.provider)
 
 
 def test_detect_language_empty_returns_unknown():
@@ -77,7 +111,21 @@ def test_detect_language_unknown_for_unscored_latin_text():
     assert detect_language("qwerty zxcv asdf") == "unknown"
 
 
-def test_detect_language_uses_optional_langdetect(monkeypatch):
+def test_detect_language_handles_invalid_sample_limit(monkeypatch):
+    monkeypatch.setenv("ALCOVE_LANGUAGE_MAX_CHARS", "wide")
+
+    assert detect_language("The family history interview") == "en"
+
+
+def test_get_language_detector_can_disable_detection(monkeypatch):
+    monkeypatch.setenv("ALCOVE_LANGUAGE_PROVIDER", "none")
+
+    detector = get_language_detector()
+
+    assert detector.detect("The family history interview").language == "unknown"
+
+
+def test_detect_language_uses_configured_langdetect_provider(monkeypatch):
     fake_module = types.ModuleType("langdetect")
 
     class FakeDetectorFactory:
@@ -86,19 +134,24 @@ def test_detect_language_uses_optional_langdetect(monkeypatch):
     class FakeLangDetectException(Exception):
         pass
 
+    class FakeLang:
+        lang = "pt"
+        prob = 0.91
+
     def detect_portuguese(sample):
-        return "pt"
+        return [FakeLang()]
 
     fake_module.DetectorFactory = FakeDetectorFactory
     fake_module.LangDetectException = FakeLangDetectException
-    fake_module.detect = detect_portuguese
+    fake_module.detect_langs = detect_portuguese
     monkeypatch.setitem(sys.modules, "langdetect", fake_module)
+    monkeypatch.setenv("ALCOVE_LANGUAGE_PROVIDER", "langdetect")
 
     assert detect_language("texto em portugues") == "pt"
     assert FakeDetectorFactory.seed == 0
 
 
-def test_detect_language_falls_back_on_langdetect_exception(monkeypatch):
+def test_langdetect_provider_returns_unknown_on_low_confidence(monkeypatch):
     fake_module = types.ModuleType("langdetect")
 
     class FakeDetectorFactory:
@@ -107,15 +160,121 @@ def test_detect_language_falls_back_on_langdetect_exception(monkeypatch):
     class FakeLangDetectException(Exception):
         pass
 
-    def fail_detect(sample):
-        raise FakeLangDetectException("not enough text")
+    class FakeLang:
+        lang = "es"
+        prob = 0.40
+
+    def detect_low_confidence(sample):
+        return [FakeLang()]
 
     fake_module.DetectorFactory = FakeDetectorFactory
     fake_module.LangDetectException = FakeLangDetectException
-    fake_module.detect = fail_detect
+    fake_module.detect_langs = detect_low_confidence
     monkeypatch.setitem(sys.modules, "langdetect", fake_module)
 
-    assert detect_language("The family history interview") == "en"
+    detector = LangdetectLanguageDetector(confidence_threshold=0.75)
+
+    assert detector.detect("La familia").language == "unknown"
+
+
+def test_transformers_provider_uses_configured_model(monkeypatch):
+    fake_module = types.ModuleType("transformers")
+    calls = {}
+
+    def fake_pipeline(task, model):
+        calls["task"] = task
+        calls["model"] = model
+
+        def classify(sample, truncation=True):
+            calls["sample"] = sample
+            calls["truncation"] = truncation
+            return [{"label": "es", "score": 0.97}]
+
+        return classify
+
+    fake_module.pipeline = fake_pipeline
+    monkeypatch.setitem(sys.modules, "transformers", fake_module)
+
+    detector = TransformersLanguageDetector(model_name="local-language-id")
+
+    assert detector.detect("La familia").language == "es"
+    assert calls == {
+        "task": "text-classification",
+        "model": "local-language-id",
+        "sample": "La familia",
+        "truncation": True,
+    }
+
+
+def test_ollama_provider_reads_json_language_response(monkeypatch):
+    calls = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps({"response": json.dumps({"language": "fr"})}).encode("utf-8")
+
+    def fake_urlopen(request, timeout):
+        calls["url"] = request.full_url
+        calls["timeout"] = timeout
+        calls["body"] = json.loads(request.data.decode("utf-8"))
+        return FakeResponse()
+
+    monkeypatch.setattr("alcove.index.language.urllib.request.urlopen", fake_urlopen)
+
+    detector = OllamaLanguageDetector(
+        model_name="llama3.2",
+        base_url="http://127.0.0.1:11434",
+        timeout=5,
+    )
+
+    assert detector.detect("Bonjour la famille").language == "fr"
+    assert calls["url"] == "http://127.0.0.1:11434/api/generate"
+    assert calls["timeout"] == 5
+    assert calls["body"]["model"] == "llama3.2"
+    assert calls["body"]["format"] == "json"
+
+
+def test_ollama_provider_returns_unknown_for_unparseable_response(monkeypatch):
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return json.dumps({"response": "not-json"}).encode("utf-8")
+
+    monkeypatch.setattr(
+        "alcove.index.language.urllib.request.urlopen",
+        lambda request, timeout: FakeResponse(),
+    )
+
+    detector = OllamaLanguageDetector()
+
+    assert detector.detect("Bonjour la famille").language == "unknown"
+
+
+def test_plugin_language_detector_can_be_selected(monkeypatch):
+    class CustomDetector:
+        provider = "custom"
+
+        def detect(self, text):
+            return LanguageDetection("tlh", 1.0, self.provider)
+
+    monkeypatch.setenv("ALCOVE_LANGUAGE_PROVIDER", "custom")
+    monkeypatch.setattr(
+        "alcove.plugins.discover_language_detectors",
+        lambda: {"custom": CustomDetector},
+    )
+
+    assert detect_language("nuqneH") == "tlh"
 
 
 def test_index_pipeline_writes_language_metadata(tmp_path, monkeypatch):
@@ -143,13 +302,43 @@ def test_index_pipeline_writes_language_metadata(tmp_path, monkeypatch):
         return backend
 
     monkeypatch.setattr(pipeline, "get_backend", get_backend)
+    detector = _FakeLanguageDetector()
+    monkeypatch.setattr(pipeline, "get_language_detector", lambda: detector)
 
     total = pipeline.run(chunks_file=str(chunks_file))
 
     assert total == 2
+    assert detector.seen == [row["chunk"] for row in rows]
     metadatas = backend.add_calls[0]["metadatas"]
     assert [meta["source"] for meta in metadatas] == ["english.txt", "spanish.txt"]
     assert [meta["language"] for meta in metadatas] == ["en", "es"]
+
+
+def test_index_pipeline_preserves_existing_language_without_detector(tmp_path, monkeypatch):
+    from alcove.index import pipeline
+
+    chunks_file = tmp_path / "chunks.jsonl"
+    chunks_file.write_text(
+        json.dumps({
+            "id": "a:0",
+            "source": "tagged.txt",
+            "chunk": "Already tagged.",
+            "language": "FR",
+        }),
+        encoding="utf-8",
+    )
+
+    backend = _CaptureBackend()
+    monkeypatch.setattr(pipeline, "get_embedder", _FakeEmbedder)
+    monkeypatch.setattr(pipeline, "get_backend", lambda _embedder: backend)
+    monkeypatch.setattr(
+        pipeline,
+        "get_language_detector",
+        lambda: (_ for _ in ()).throw(AssertionError("detector should not load")),
+    )
+
+    assert pipeline.run(chunks_file=str(chunks_file)) == 1
+    assert backend.add_calls[0]["metadatas"][0]["language"] == "fr"
 
 
 def test_retriever_passes_language_filter(monkeypatch):
@@ -241,6 +430,35 @@ def test_keyword_search_can_filter_by_collection_after_scoring(tmp_path):
 
     assert result["ids"] == [["minutes:0"]]
     assert result["metadatas"][0][0]["collection"] == "minutes"
+
+
+def test_keyword_search_uses_existing_language_without_detector(tmp_path, monkeypatch):
+    from alcove.index import keyword
+
+    chunks_file = tmp_path / "chunks.jsonl"
+    chunks_file.write_text(
+        json.dumps({
+            "id": "fr:0",
+            "source": "french.txt",
+            "language": "FR",
+            "chunk": "famille histoire communaute",
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        keyword,
+        "get_language_detector",
+        lambda: (_ for _ in ()).throw(AssertionError("detector should not load")),
+    )
+
+    result = keyword.KeywordIndex(str(chunks_file)).search(
+        "famille histoire",
+        k=1,
+        language_filter="fr",
+    )
+
+    assert result["ids"] == [["fr:0"]]
+    assert result["metadatas"][0][0]["language"] == "fr"
 
 
 def test_api_dispatch_keyword_passes_collection_and_language(monkeypatch):

--- a/tests/test_language_metadata.py
+++ b/tests/test_language_metadata.py
@@ -219,6 +219,7 @@ def test_langdetect_provider_handles_detection_exception(monkeypatch):
 
 
 def test_langdetect_provider_reports_missing_dependency(monkeypatch):
+    monkeypatch.delitem(sys.modules, "langdetect", raising=False)
     original_import = __import__
 
     def fake_import(name, *args, **kwargs):
@@ -229,7 +230,7 @@ def test_langdetect_provider_reports_missing_dependency(monkeypatch):
     monkeypatch.setattr("builtins.__import__", fake_import)
 
     with pytest.raises(RuntimeError, match="langdetect"):
-        LangdetectLanguageDetector().detect("The family history interview")
+        LangdetectLanguageDetector()
 
 
 def test_transformers_provider_uses_configured_model(monkeypatch):
@@ -277,6 +278,7 @@ def test_transformers_provider_handles_empty_and_low_confidence(monkeypatch):
 
 
 def test_transformers_provider_reports_missing_dependency(monkeypatch):
+    monkeypatch.delitem(sys.modules, "transformers", raising=False)
     original_import = __import__
 
     def fake_import(name, *args, **kwargs):
@@ -349,7 +351,7 @@ def test_ollama_provider_returns_unknown_for_unparseable_response(monkeypatch):
     assert detector.detect("Bonjour la famille").language == "unknown"
 
 
-def test_ollama_provider_reports_http_and_url_errors(monkeypatch):
+def test_ollama_provider_returns_unknown_for_http_and_url_errors(monkeypatch):
     def raise_http(request, timeout):
         raise urllib.error.HTTPError(
             request.full_url,
@@ -362,19 +364,35 @@ def test_ollama_provider_reports_http_and_url_errors(monkeypatch):
     monkeypatch.setattr("alcove.index.language.urllib.request.urlopen", raise_http)
     detector = OllamaLanguageDetector(base_url="http://127.0.0.1:11434")
 
-    with pytest.raises(RuntimeError, match="HTTP 500"):
-        detector.detect("Bonjour")
+    assert detector.detect("Bonjour").language == "unknown"
 
     def raise_url(request, timeout):
         raise urllib.error.URLError("offline")
 
     monkeypatch.setattr("alcove.index.language.urllib.request.urlopen", raise_url)
 
-    with pytest.raises(RuntimeError, match="Could not reach Ollama"):
-        detector.detect("Bonjour")
+    assert detector.detect("Bonjour").language == "unknown"
+
+
+def test_ollama_provider_preserves_explicit_zero_timeout():
+    detector = OllamaLanguageDetector(timeout=0.0)
+
+    assert detector.timeout == 0.0
 
 
 def test_invalid_confidence_env_falls_back(monkeypatch):
+    fake_module = types.ModuleType("langdetect")
+
+    class FakeDetectorFactory:
+        seed = None
+
+    class FakeLangDetectException(Exception):
+        pass
+
+    fake_module.DetectorFactory = FakeDetectorFactory
+    fake_module.LangDetectException = FakeLangDetectException
+    fake_module.detect_langs = lambda sample: []
+    monkeypatch.setitem(sys.modules, "langdetect", fake_module)
     monkeypatch.setenv("ALCOVE_LANGUAGE_CONFIDENCE_THRESHOLD", "wide")
 
     detector = LangdetectLanguageDetector()
@@ -438,6 +456,22 @@ def test_plugin_language_detector_can_be_selected(monkeypatch):
     )
 
     assert detect_language("nuqneH") == "tlh"
+
+
+def test_plugin_language_detector_can_use_underscore_name(monkeypatch):
+    class CustomDetector:
+        provider = "my_lang"
+
+        def detect(self, text):
+            return LanguageDetection("tlh", 1.0, self.provider)
+
+    monkeypatch.setenv("ALCOVE_LANGUAGE_PROVIDER", "my_lang")
+    monkeypatch.setattr(
+        "alcove.plugins.discover_language_detectors",
+        lambda: {"my_lang": CustomDetector},
+    )
+
+    assert get_language_detector().detect("nuqneH").language == "tlh"
 
 
 def test_index_pipeline_writes_language_metadata(tmp_path, monkeypatch):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -10,6 +10,7 @@ from alcove.plugins import (
     discover_extractors,
     discover_backends,
     discover_embedders,
+    discover_language_detectors,
     list_plugins,
 )
 
@@ -71,6 +72,20 @@ class TestDiscoverEmbedders:
             assert result["cohere"] is fake_cls
 
 
+class TestDiscoverLanguageDetectors:
+    def test_returns_empty_when_no_plugins(self):
+        with patch("alcove.plugins.entry_points", return_value=[]):
+            assert discover_language_detectors() == {}
+
+    def test_discovers_language_detector_plugin(self):
+        fake_cls = type("CustomLanguageDetector", (), {})
+        ep = _make_entry_point("custom", "alcove_lang:CustomLanguageDetector", fake_cls)
+        with patch("alcove.plugins.entry_points", return_value=[ep]):
+            result = discover_language_detectors()
+            assert "custom" in result
+            assert result["custom"] is fake_cls
+
+
 class TestListPlugins:
     def test_empty_when_no_plugins(self):
         with patch("alcove.plugins.entry_points", return_value=[]):
@@ -80,19 +95,21 @@ class TestListPlugins:
         ext_ep = _make_entry_point("docx", "alcove_docx:extract_docx")
         backend_ep = _make_entry_point("milvus", "alcove_milvus:Milvus")
         embedder_ep = _make_entry_point("cohere", "alcove_cohere:Cohere")
+        language_ep = _make_entry_point("custom", "alcove_lang:Detector")
 
         def fake_entry_points(*, group):
             return {
                 "alcove.extractors": [ext_ep],
                 "alcove.backends": [backend_ep],
                 "alcove.embedders": [embedder_ep],
+                "alcove.language_detectors": [language_ep],
             }.get(group, [])
 
         with patch("alcove.plugins.entry_points", side_effect=fake_entry_points):
             plugins = list_plugins()
-            assert len(plugins) == 3
+            assert len(plugins) == 4
             types = {p["type"] for p in plugins}
-            assert types == {"extractor", "backend", "embedder"}
+            assert types == {"extractor", "backend", "embedder", "language_detector"}
 
 
 class TestPipelineUsesPlugins:
@@ -138,6 +155,23 @@ class TestEmbedderUsesPlugins:
         with patch("alcove.plugins.discover_embedders", return_value={"custom-emb": fake_cls}):
             from alcove.index.embedder import get_embedder
             result = get_embedder()
+
+        fake_cls.assert_called_once()
+        assert result is fake_instance
+
+
+class TestLanguageDetectorUsesPlugins:
+    def test_plugin_language_detector_used_when_configured(self, monkeypatch):
+        fake_instance = MagicMock()
+        fake_cls = MagicMock(return_value=fake_instance)
+
+        monkeypatch.setenv("ALCOVE_LANGUAGE_PROVIDER", "custom-lang")
+        with patch(
+            "alcove.plugins.discover_language_detectors",
+            return_value={"custom-lang": fake_cls},
+        ):
+            from alcove.index.language import get_language_detector
+            result = get_language_detector()
 
         fake_cls.assert_called_once()
         assert result is fake_instance

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -165,10 +165,10 @@ class TestLanguageDetectorUsesPlugins:
         fake_instance = MagicMock()
         fake_cls = MagicMock(return_value=fake_instance)
 
-        monkeypatch.setenv("ALCOVE_LANGUAGE_PROVIDER", "custom-lang")
+        monkeypatch.setenv("ALCOVE_LANGUAGE_PROVIDER", "custom_lang")
         with patch(
             "alcove.plugins.discover_language_detectors",
-            return_value={"custom-lang": fake_cls},
+            return_value={"custom_lang": fake_cls},
         ):
             from alcove.index.language import get_language_detector
             result = get_language_detector()


### PR DESCRIPTION
## Summary

- Adds best-effort local language detection metadata during indexing.
- Threads `language_filter` through semantic, keyword, and hybrid retrieval.
- Supports language filtering in `/query` and `/search` while keeping detection local.
- Updates CHANGELOG and ROADMAP.

## Safety and privacy

- Detection is local and deterministic by default, with optional local `langdetect` use when installed.
- Adds no private deployment details, hostnames, or implementation notes.

## Tests

- python3 -m pytest tests/test_language_metadata.py tests/test_backend.py tests/test_keyword.py tests/test_api.py -q
- python3 -m pytest tests/test_multi_collection.py -q
- python3 -m pytest -q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-chunk language metadata at index time; query/search endpoints accept a language_filter and results include language
  * Keyword and hybrid retrieval honor language filtering; language-aware backend filtering and collection scoping

* **Plugins**
  * Plugin category for custom language detectors; configurable provider selection and options

* **Documentation**
  * Roadmap, architecture, and operations docs updated for language metadata and provider config

* **Tests**
  * Extensive tests covering detection, indexing, retrieval, API, backend filtering, and plugins

* **Chores**
  * Added optional "language" dependency extra to packaging

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Spitfire-Cowboy/alcove/pull/122)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->