### PR TITLE
Add Congress data loaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to alcove-search.
 
+## [Unreleased]
+
+- Add GovInfo Congress bill summary and bill status data loaders for retrieval indexes.
+
 ## [0.3.0] - 2026-03-07
 
 - Add theme toggle, fix WCAG AA contrast, update accessibility docs

--- a/alcove/govdata/__init__.py
+++ b/alcove/govdata/__init__.py
@@ -1,0 +1,2 @@
+"""Public government data helpers for Alcove retrieval indexes."""
+

--- a/alcove/govdata/congress.py
+++ b/alcove/govdata/congress.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import tempfile
+import urllib.request
+import zipfile
+from collections.abc import Iterable
+from html import unescape
+from pathlib import Path
+
+from defusedxml import ElementTree as ET
+
+CONGRESS_SUMMARIES_COLLECTION = "congress_summaries"
+GOVINFO_SUMMARY_DETAILS_URL = "https://www.govinfo.gov/app/details/BILLSUM-{congress}{bill_type}{bill_number}"
+SUMMARY_ID_RE = re.compile(
+    r"^id(?P<congress>\d+)(?P<bill_type>[a-z]+)(?P<bill_number>\d+)(?P<version>v\d+)$",
+    re.IGNORECASE,
+)
+TAG_STRIPPER = re.compile(r"<[^>]+>")
+WHITESPACE = re.compile(r"\s+")
+
+
+def ingest_billsum(
+    source: str | Path | None = None,
+    *,
+    source_url: str | None = None,
+    collection_name: str = CONGRESS_SUMMARIES_COLLECTION,
+    jsonl_out: str | Path | None = None,
+) -> int:
+    records = _apply_collection_name(
+        load_billsum_records(source=source, source_url=source_url),
+        collection_name=collection_name,
+    )
+    if jsonl_out is not None:
+        write_jsonl(records, jsonl_out)
+    return index_billsum_records(records, collection_name=collection_name)
+
+
+def load_billsum_records(
+    source: str | Path | None = None,
+    *,
+    source_url: str | None = None,
+) -> list[dict]:
+    if not source and not source_url:
+        raise ValueError("Provide a local BILLSUM source path or source_url.")
+
+    if source_url:
+        with tempfile.TemporaryDirectory(prefix="alcove-congress-") as tmpdir:
+            temp_path = Path(tmpdir) / (Path(source_url).name or "billsum.xml")
+            download_file(source_url, temp_path)
+            return load_billsum_records(source=temp_path)
+
+    path = Path(source)
+    if not path.exists():
+        raise FileNotFoundError(path)
+    if path.is_dir():
+        return _load_billsum_records_from_directory(path)
+    if path.suffix.lower() == ".zip":
+        return _load_billsum_records_from_zip(path)
+    if path.suffix.lower() == ".xml":
+        return parse_billsum_xml(path.read_text(encoding="utf-8"), source=str(path))
+    if path.suffix.lower() == ".jsonl":
+        return _load_billsum_records_from_jsonl(path)
+    raise ValueError(f"Unsupported BILLSUM source: {path}")
+
+
+def parse_billsum_xml(xml_text: str, *, source: str = "billsum.xml") -> list[dict]:
+    root = ET.fromstring(xml_text)
+    if _find_all(root, "item"):
+        return _parse_govinfo_billsum_items(root, source=source)
+    return _parse_summary_nodes(root, source=source)
+
+
+def index_billsum_records(
+    records: Iterable[dict],
+    *,
+    collection_name: str = CONGRESS_SUMMARIES_COLLECTION,
+) -> int:
+    materialized = _apply_collection_name(records, collection_name=collection_name)
+    if not materialized:
+        return 0
+
+    get_embedder, get_backend = _load_indexing_dependencies()
+    embedder = get_embedder()
+    backend = get_backend(embedder)
+    documents = [record["document"] for record in materialized]
+    metadatas = [dict(record["metadata"]) for record in materialized]
+
+    backend.add(
+        ids=[record["id"] for record in materialized],
+        embeddings=embedder.embed(documents),
+        documents=documents,
+        metadatas=metadatas,
+    )
+    return len(materialized)
+
+
+def write_jsonl(records: Iterable[dict], output_path: str | Path) -> Path:
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    return output_path
+
+
+def download_file(url: str, destination: str | Path) -> Path:
+    destination = Path(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with urllib.request.urlopen(url) as response, destination.open("wb") as fh:
+        shutil.copyfileobj(response, fh)
+    return destination
+
+
+def _apply_collection_name(records: Iterable[dict], *, collection_name: str) -> list[dict]:
+    normalized = []
+    for record in records:
+        metadata = dict(record["metadata"])
+        metadata["collection"] = collection_name
+        normalized.append(
+            {
+                "id": record["id"],
+                "document": record["document"],
+                "metadata": metadata,
+            }
+        )
+    return normalized
+
+
+def _load_billsum_records_from_directory(directory: Path) -> list[dict]:
+    records: list[dict] = []
+    for path in sorted(directory.rglob("*")):
+        if path.is_dir():
+            continue
+        if path.suffix.lower() == ".xml":
+            records.extend(parse_billsum_xml(path.read_text(encoding="utf-8"), source=str(path)))
+        elif path.suffix.lower() == ".zip":
+            records.extend(_load_billsum_records_from_zip(path))
+    return records
+
+
+def _load_billsum_records_from_zip(path: Path) -> list[dict]:
+    records: list[dict] = []
+    with zipfile.ZipFile(path) as archive:
+        for member in sorted(archive.namelist()):
+            if not member.lower().endswith(".xml"):
+                continue
+            xml_text = archive.read(member).decode("utf-8")
+            records.extend(parse_billsum_xml(xml_text, source=f"{path}!{member}"))
+    return records
+
+
+def _load_billsum_records_from_jsonl(path: Path) -> list[dict]:
+    records: list[dict] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            raw = json.loads(line)
+            if not isinstance(raw, dict):
+                continue
+            record_id = str(raw.get("id") or "").strip()
+            document = str(raw.get("document") or "").strip()
+            metadata = raw.get("metadata")
+            if not record_id or not document or not isinstance(metadata, dict):
+                continue
+            records.append(
+                {
+                    "id": record_id,
+                    "document": document,
+                    "metadata": dict(metadata),
+                }
+            )
+    return records
+
+
+def _parse_govinfo_billsum_items(root: ET.Element, *, source: str) -> list[dict]:
+    records: list[dict] = []
+    for item in _find_all(root, "item"):
+        congress = _coerce_int(item.attrib.get("congress") or _first_text(item, "congress"))
+        bill_type = _normalize_bill_type(item.attrib.get("measure-type") or _first_text(item, "billType", "bill-type"))
+        bill_number = _coerce_int(item.attrib.get("measure-number") or _first_text(item, "billNumber", "bill-number"))
+        title = _first_text(item, "title")
+        origin_chamber = (item.attrib.get("originChamber") or "").strip().upper()
+        publish_date = (item.attrib.get("orig-publish-date") or "").strip()
+        update_date = (item.attrib.get("update-date") or "").strip()
+
+        if not congress or not bill_type or not bill_number:
+            continue
+
+        summaries = [node for node in item if _local_name(node.tag).lower() == "summary"]
+        for index, summary in enumerate(summaries, start=1):
+            version = _extract_summary_version(summary, fallback_index=index)
+            action_date = _first_text(summary, "actionDate", "action-date")
+            action_desc = _first_text(summary, "actionDesc", "action-desc")
+            current_chamber = (summary.attrib.get("currentChamber") or "").strip().upper()
+            body = _clean_summary_text(_extract_summary_text(summary))
+            if not body:
+                continue
+
+            section = f"summary-{version}"
+            display_title = title or f"{bill_type.upper()} {bill_number}"
+            records.append(
+                {
+                    "id": f"bill-{congress}-{bill_type}-{bill_number}-{section}",
+                    "document": f"{display_title}\n\n{body}",
+                    "metadata": {
+                        "source": source,
+                        "collection": CONGRESS_SUMMARIES_COLLECTION,
+                        "congress": str(congress),
+                        "bill_type": bill_type,
+                        "bill_number": str(bill_number),
+                        "version": version,
+                        "section": section,
+                        "title": display_title,
+                        "is_summary": True,
+                        "date_issued": action_date or update_date or publish_date,
+                        "action_desc": action_desc or "",
+                        "origin_chamber": origin_chamber,
+                        "current_chamber": current_chamber,
+                        "publish_date": publish_date,
+                        "update_date": update_date,
+                        "url": GOVINFO_SUMMARY_DETAILS_URL.format(
+                            congress=congress,
+                            bill_type=bill_type,
+                            bill_number=bill_number,
+                        ),
+                        "source_format": "govinfo-billsum-xml",
+                    },
+                }
+            )
+    return records
+
+
+def _parse_summary_nodes(root: ET.Element, *, source: str) -> list[dict]:
+    records: list[dict] = []
+    root_congress = _first_text(root, "congress")
+
+    for index, summary in enumerate(_find_all(root, "summary"), start=1):
+        congress = _first_text(summary, "congress") or root_congress
+        bill_type = _normalize_bill_type(_first_text(summary, "billType", "bill-type"))
+        bill_number = _first_text(summary, "billNumber", "bill-number")
+        title = _first_text(summary, "title") or _first_text(summary, "titles", "title")
+        version = _first_text(summary, "version") or f"legacy-{index}"
+        issued = _first_text(summary, "actionDate", "action-date", "updateDate", "update-date")
+        body = _clean_summary_text(_first_text(summary, "text", "summaryText", "summary-text"))
+
+        if not congress or not bill_type or not bill_number or not body:
+            continue
+
+        section = f"summary-{version}"
+        records.append(
+            {
+                "id": f"bill-{congress}-{bill_type}-{bill_number}-{section}",
+                "document": f"{title}\n\n{body}" if title else body,
+                "metadata": {
+                    "source": source,
+                    "collection": CONGRESS_SUMMARIES_COLLECTION,
+                    "congress": str(congress),
+                    "bill_type": bill_type,
+                    "bill_number": str(bill_number),
+                    "version": version,
+                    "section": section,
+                    "title": title or f"{bill_type.upper()} {bill_number}",
+                    "is_summary": True,
+                    "date_issued": issued or "",
+                    "url": GOVINFO_SUMMARY_DETAILS_URL.format(
+                        congress=congress,
+                        bill_type=bill_type,
+                        bill_number=bill_number,
+                    ),
+                    "source_format": "govinfo-billsum-xml",
+                },
+            }
+        )
+
+    return records
+
+
+def _extract_summary_text(summary: ET.Element) -> str:
+    for name in ("summary-text", "summaryText", "text"):
+        node = _first_node(summary, name)
+        if node is not None:
+            return "".join(node.itertext()).strip()
+    return ""
+
+
+def _extract_summary_version(summary: ET.Element, *, fallback_index: int) -> str:
+    summary_id = (summary.attrib.get("summary-id") or "").strip()
+    if summary_id:
+        match = SUMMARY_ID_RE.match(summary_id)
+        if match:
+            return match.group("version").lower()
+        version_match = re.search(r"(v\d+)$", summary_id, re.IGNORECASE)
+        if version_match:
+            return version_match.group(1).lower()
+
+    version = _first_text(summary, "version")
+    if version:
+        return _normalize_version(version)
+
+    return f"v{fallback_index:02d}"
+
+
+def _load_indexing_dependencies():
+    from alcove.index.backend import get_backend
+    from alcove.index.embedder import get_embedder
+
+    return get_embedder, get_backend
+
+
+def _find_all(root: ET.Element, name: str) -> list[ET.Element]:
+    target = name.lower()
+    return [node for node in root.iter() if _local_name(node.tag).lower() == target]
+
+
+def _first_node(root: ET.Element, *names: str) -> ET.Element | None:
+    wanted = {name.lower() for name in names}
+    for node in root.iter():
+        if _local_name(node.tag).lower() in wanted:
+            return node
+    return None
+
+
+def _first_text(root: ET.Element, *names: str) -> str | None:
+    node = _first_node(root, *names)
+    if node is None:
+        return None
+    text = "".join(node.itertext()).strip()
+    return text or None
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _normalize_bill_type(value: str | None) -> str:
+    if not value:
+        return ""
+    return re.sub(r"[^a-z0-9]", "", value.lower())
+
+
+def _normalize_version(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]", "", value.lower())
+    return normalized or "v00"
+
+
+def _coerce_int(value: str | None) -> int | None:
+    if value is None:
+        return None
+    text = value.strip()
+    if text.isdigit():
+        return int(text)
+    return None
+
+
+def _clean_summary_text(value: str | None) -> str:
+    if not value:
+        return ""
+    text = unescape(value)
+    text = TAG_STRIPPER.sub(" ", text)
+    return WHITESPACE.sub(" ", text).strip()

--- a/alcove/govdata/congress_billstatus.py
+++ b/alcove/govdata/congress_billstatus.py
@@ -1,0 +1,424 @@
+"""GovInfo BILLSTATUS ingest helpers for Alcove retrieval indexes."""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import tempfile
+import urllib.request
+import zipfile
+from collections.abc import Iterable
+from pathlib import Path
+
+from defusedxml import ElementTree as ET
+
+CONGRESS_BILLSTATUS_COLLECTION = "congress_billstatus"
+GOVINFO_BILLSTATUS_SITEMAP = (
+    "https://www.govinfo.gov/sitemap/bulkdata/BILLSTATUS/{congress}{bill_type}/sitemap.xml"
+)
+CONGRESS_GOV_URL = "https://www.congress.gov/bill/{congress}th-congress/{chamber}/{bill_number}"
+
+
+def ingest_billstatus(
+    source: str | Path | None = None,
+    *,
+    source_url: str | None = None,
+    congress: int | None = None,
+    bill_type: str | None = None,
+    collection_name: str = CONGRESS_BILLSTATUS_COLLECTION,
+    jsonl_out: str | Path | None = None,
+    limit: int | None = None,
+) -> int:
+    records = _apply_collection_name(
+        load_billstatus_records(
+            source=source,
+            source_url=source_url,
+            congress=congress,
+            bill_type=bill_type,
+            limit=limit,
+        ),
+        collection_name=collection_name,
+    )
+    if jsonl_out is not None:
+        write_jsonl(records, jsonl_out)
+    return index_billstatus_records(records, collection_name=collection_name)
+
+
+def load_billstatus_records(
+    source: str | Path | None = None,
+    *,
+    source_url: str | None = None,
+    congress: int | None = None,
+    bill_type: str | None = None,
+    limit: int | None = None,
+) -> list[dict]:
+    if source:
+        return _load_from_source(Path(source), limit=limit)
+    if source_url:
+        return _load_from_url(source_url, limit=limit)
+    if congress is not None and bill_type is not None:
+        return _load_from_sitemap(congress, bill_type.lower(), limit=limit)
+    raise ValueError("Provide a local source path, source_url, or both congress and bill_type.")
+
+
+def parse_billstatus_xml(xml_text: str, *, source: str = "billstatus.xml") -> list[dict]:
+    root = ET.fromstring(xml_text)
+    bill = _first_node(root, "bill")
+    if bill is None:
+        return []
+    return _parse_bill(bill, source=source)
+
+
+def index_billstatus_records(
+    records: Iterable[dict],
+    *,
+    collection_name: str = CONGRESS_BILLSTATUS_COLLECTION,
+) -> int:
+    materialized = _apply_collection_name(records, collection_name=collection_name)
+    if not materialized:
+        return 0
+
+    get_embedder, get_backend = _load_indexing_dependencies()
+    embedder = get_embedder()
+    backend = get_backend(embedder)
+    documents = [record["document"] for record in materialized]
+    metadatas = [dict(record["metadata"]) for record in materialized]
+
+    backend.add(
+        ids=[record["id"] for record in materialized],
+        embeddings=embedder.embed(documents),
+        documents=documents,
+        metadatas=metadatas,
+    )
+    return len(materialized)
+
+
+def write_jsonl(records: Iterable[dict], output_path: str | Path) -> Path:
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    return output_path
+
+
+def download_file(url: str, destination: str | Path) -> Path:
+    destination = Path(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with urllib.request.urlopen(url) as response, destination.open("wb") as fh:
+        shutil.copyfileobj(response, fh)
+    return destination
+
+
+def _load_from_source(path: Path, limit: int | None = None) -> list[dict]:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    if path.is_dir():
+        return _load_from_directory(path, limit=limit)
+    if path.suffix.lower() == ".zip":
+        return _load_from_zip(path, limit=limit)
+    if path.suffix.lower() == ".xml":
+        return parse_billstatus_xml(path.read_text(encoding="utf-8"), source=str(path))
+    if path.suffix.lower() == ".jsonl":
+        return _load_from_jsonl(path, limit=limit)
+    raise ValueError(f"Unsupported BILLSTATUS source: {path}")
+
+
+def _load_from_url(url: str, limit: int | None = None) -> list[dict]:
+    with tempfile.TemporaryDirectory(prefix="alcove-billstatus-") as tmpdir:
+        temp_path = Path(tmpdir) / (Path(url).name or "billstatus.xml")
+        download_file(url, temp_path)
+        return _load_from_source(temp_path, limit=limit)
+
+
+def _load_from_directory(directory: Path, limit: int | None = None) -> list[dict]:
+    records: list[dict] = []
+    for path in sorted(directory.rglob("*")):
+        if path.is_dir():
+            continue
+        if path.suffix.lower() == ".xml":
+            records.extend(parse_billstatus_xml(path.read_text(encoding="utf-8"), source=str(path)))
+        elif path.suffix.lower() == ".zip":
+            records.extend(_load_from_zip(path))
+        if limit is not None and len(records) >= limit:
+            break
+    return records[:limit] if limit is not None else records
+
+
+def _load_from_zip(path: Path, limit: int | None = None) -> list[dict]:
+    records: list[dict] = []
+    with zipfile.ZipFile(path) as archive:
+        for member in sorted(archive.namelist()):
+            if not member.lower().endswith(".xml"):
+                continue
+            xml_text = archive.read(member).decode("utf-8")
+            records.extend(parse_billstatus_xml(xml_text, source=f"{path}!{member}"))
+            if limit is not None and len(records) >= limit:
+                break
+    return records[:limit] if limit is not None else records
+
+
+def _load_from_jsonl(path: Path, limit: int | None = None) -> list[dict]:
+    records: list[dict] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            raw = json.loads(line)
+            metadata = raw.get("metadata") if isinstance(raw, dict) else None
+            if isinstance(raw, dict) and raw.get("id") and raw.get("document") and isinstance(metadata, dict):
+                records.append({"id": str(raw["id"]), "document": str(raw["document"]), "metadata": dict(metadata)})
+            if limit is not None and len(records) >= limit:
+                break
+    return records
+
+
+def _load_from_sitemap(congress: int, bill_type: str, limit: int | None = None) -> list[dict]:
+    sitemap_url = GOVINFO_BILLSTATUS_SITEMAP.format(congress=congress, bill_type=bill_type)
+    with urllib.request.urlopen(sitemap_url, timeout=30) as response:
+        sitemap_xml = response.read().decode("utf-8")
+
+    sitemap_root = ET.fromstring(sitemap_xml)
+    urls = [
+        node.text.strip()
+        for node in sitemap_root.iter()
+        if _local_name(node.tag).lower() == "loc" and node.text and node.text.strip().endswith(".xml")
+    ]
+
+    records: list[dict] = []
+    for url in urls:
+        try:
+            with urllib.request.urlopen(url, timeout=30) as response:
+                xml_text = response.read().decode("utf-8")
+            records.extend(parse_billstatus_xml(xml_text, source=url))
+        except Exception:
+            continue
+        if limit is not None and len(records) >= limit:
+            break
+    return records[:limit] if limit is not None else records
+
+
+def _parse_bill(bill: ET.Element, *, source: str) -> list[dict]:
+    congress = _text(bill, "congress")
+    bill_type = _normalize_bill_type(_text(bill, "type"))
+    bill_number = _text(bill, "number")
+    introduced_date = _text(bill, "introducedDate") or ""
+    origin_chamber = _text(bill, "originChamber") or ""
+    legislation_url = _text(bill, "legislationUrl") or ""
+    update_date = _text(bill, "updateDate") or ""
+
+    if not congress or not bill_type or not bill_number:
+        return []
+
+    title = _extract_display_title(bill) or _text(bill, "title") or f"{bill_type.upper()} {bill_number}"
+    policy_area = _text_nested(bill, "policyArea", "name") or ""
+
+    sponsor_node = _first_child_node(_first_node(bill, "sponsors"), "item")
+    sponsor_name = _text(sponsor_node, "fullName") or "" if sponsor_node is not None else ""
+    sponsor_party = _text(sponsor_node, "party") or "" if sponsor_node is not None else ""
+    sponsor_state = _text(sponsor_node, "state") or "" if sponsor_node is not None else ""
+    sponsor_bioguide = _text(sponsor_node, "bioguideId") or "" if sponsor_node is not None else ""
+
+    cosponsor_items = _find_all(_first_node(bill, "cosponsors"), "item")
+    cosponsor_names = "; ".join(_text(cosponsor, "fullName") or "" for cosponsor in cosponsor_items[:10])
+
+    committees_node = _first_node(bill, "committees")
+    top_level_committees: list[str] = []
+    if committees_node is not None:
+        for item in committees_node:
+            if _local_name(item.tag).lower() == "item":
+                name = _text(item, "name")
+                if name:
+                    top_level_committees.append(name)
+    committees = "; ".join(top_level_committees)
+
+    action_items = _find_all(_first_node(bill, "actions"), "item")
+    actions_summary = _extract_actions(action_items)
+    latest_action_node = _direct_child(bill, "latestAction")
+    latest_action_date = _text(latest_action_node, "actionDate") or "" if latest_action_node is not None else ""
+    latest_action_text = _text(latest_action_node, "text") or "" if latest_action_node is not None else ""
+    status = _derive_status(latest_action_text, action_items)
+    related_count = len(_find_all(_first_node(bill, "relatedBills"), "item"))
+
+    document_parts = [title]
+    if sponsor_name:
+        document_parts.append(f"Sponsor: {sponsor_name}")
+    if committees:
+        document_parts.append(f"Committees: {committees}")
+    if policy_area:
+        document_parts.append(f"Policy area: {policy_area}")
+    if latest_action_text:
+        document_parts.append(f"Latest action ({latest_action_date}): {latest_action_text}")
+    if actions_summary:
+        document_parts.append(f"Actions: {actions_summary}")
+
+    bill_id = f"billstatus-{congress}-{bill_type}-{bill_number}"
+    return [
+        {
+            "id": bill_id,
+            "document": "\n".join(document_parts),
+            "metadata": {
+                "source": source,
+                "collection": CONGRESS_BILLSTATUS_COLLECTION,
+                "congress": str(congress),
+                "bill_type": bill_type,
+                "bill_number": str(bill_number),
+                "bill_id": bill_id,
+                "title": title,
+                "introduced_date": introduced_date,
+                "origin_chamber": origin_chamber,
+                "update_date": update_date,
+                "sponsor_name": sponsor_name,
+                "sponsor_party": sponsor_party,
+                "sponsor_state": sponsor_state,
+                "sponsor_bioguide": sponsor_bioguide,
+                "cosponsor_count": str(len(cosponsor_items)),
+                "cosponsor_names": cosponsor_names,
+                "committees": committees,
+                "policy_area": policy_area,
+                "latest_action_date": latest_action_date,
+                "latest_action_text": latest_action_text,
+                "status": status,
+                "action_count": str(len(action_items)),
+                "related_bill_count": str(related_count),
+                "url": legislation_url or _build_congress_url(congress, bill_type, bill_number, origin_chamber),
+                "source_format": "govinfo-billstatus-xml",
+            },
+        }
+    ]
+
+
+def _extract_display_title(bill: ET.Element) -> str | None:
+    titles_node = _first_node(bill, "titles")
+    if titles_node is None:
+        return None
+    for item in titles_node:
+        if _local_name(item.tag).lower() != "item":
+            continue
+        title_type = _text(item, "titleType") or ""
+        if "display" in title_type.lower():
+            return _text(item, "title")
+    for item in titles_node:
+        if _local_name(item.tag).lower() == "item":
+            return _text(item, "title")
+    return None
+
+
+def _extract_actions(action_items: list[ET.Element]) -> str:
+    parts = []
+    for item in action_items[-5:]:
+        date = _text(item, "actionDate") or ""
+        text = _text(item, "text") or ""
+        if text:
+            parts.append(f"{date}: {text}" if date else text)
+    return "; ".join(parts)
+
+
+def _derive_status(latest_action_text: str, action_items: list[ET.Element]) -> str:
+    text = (latest_action_text or "").lower()
+    if "became public law" in text or "signed by president" in text:
+        return "enacted"
+    if "passed" in text and "senate" in text:
+        return "passed-senate"
+    if "passed" in text and "house" in text:
+        return "passed-house"
+    if "failed" in text or "defeated" in text:
+        return "failed"
+    if "vetoed" in text:
+        return "vetoed"
+    if "referred" in text:
+        return "referred"
+    if action_items:
+        return "active"
+    return "unknown"
+
+
+def _build_congress_url(congress: str, bill_type: str, bill_number: str, origin_chamber: str) -> str:
+    chamber_map = {
+        "house": "house-bill",
+        "senate": "senate-bill",
+        "h": "house-bill",
+        "s": "senate-bill",
+    }
+    chamber = chamber_map.get((origin_chamber or "").lower(), "house-bill")
+    return CONGRESS_GOV_URL.format(congress=congress, chamber=chamber, bill_number=bill_number)
+
+
+def _apply_collection_name(records: Iterable[dict], *, collection_name: str) -> list[dict]:
+    normalized = []
+    for record in records:
+        metadata = dict(record["metadata"])
+        metadata["collection"] = collection_name
+        normalized.append({"id": record["id"], "document": record["document"], "metadata": metadata})
+    return normalized
+
+
+def _load_indexing_dependencies():
+    from alcove.index.backend import get_backend
+    from alcove.index.embedder import get_embedder
+
+    return get_embedder, get_backend
+
+
+def _find_all(root: ET.Element | None, name: str) -> list[ET.Element]:
+    if root is None:
+        return []
+    target = name.lower()
+    return [node for node in root.iter() if _local_name(node.tag).lower() == target]
+
+
+def _first_node(root: ET.Element | None, *names: str) -> ET.Element | None:
+    if root is None:
+        return None
+    wanted = {name.lower() for name in names}
+    for node in root.iter():
+        if _local_name(node.tag).lower() in wanted:
+            return node
+    return None
+
+
+def _first_child_node(root: ET.Element | None, name: str) -> ET.Element | None:
+    if root is None:
+        return None
+    target = name.lower()
+    for child in root:
+        if _local_name(child.tag).lower() == target:
+            return child
+    return None
+
+
+def _direct_child(root: ET.Element | None, name: str) -> ET.Element | None:
+    if root is None:
+        return None
+    target = name.lower()
+    for child in root:
+        if _local_name(child.tag).lower() == target:
+            return child
+    return None
+
+
+def _text(root: ET.Element | None, *names: str) -> str | None:
+    node = _first_node(root, *names)
+    if node is None:
+        return None
+    text = "".join(node.itertext()).strip()
+    return text or None
+
+
+def _text_nested(root: ET.Element | None, parent_name: str, child_name: str) -> str | None:
+    parent = _first_node(root, parent_name)
+    if parent is None:
+        return None
+    return _text(parent, child_name)
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _normalize_bill_type(value: str | None) -> str:
+    if not value:
+        return ""
+    return re.sub(r"[^a-z0-9]", "", value.lower())

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,6 +20,8 @@ This is the foundation. Everything below builds on it.
 
 **Streaming ingest.** Watch a directory and re-index on change. The current pipeline is batch-oriented: you run `alcove ingest`, it processes everything. Streaming mode keeps the index current without manual intervention.
 
+**Public data loaders.** Domain-specific loaders should stay separate from the core ingest pipeline unless their format is generally useful. GovInfo Congress bill summaries and bill status records are the first public-data loaders: they normalize public XML into Alcove retrieval records without adding hosted-service assumptions.
+
 ## Mid-term
 
 **Cross-modal indexing.** Audio transcription, image OCR, video keyframe extraction. The pipeline architecture already separates extraction from embedding; new modalities plug in as extractors that produce text chunks from non-text sources. Bioacoustics and field recordings are a motivating use case, not an afterthought.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,15 +25,16 @@ dependencies = [
     "jinja2>=3.1,<4.0",
     "python-multipart>=0.0.6,<1.0",
     "rank-bm25>=0.2",
+    "defusedxml>=0.7",
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.3", "python-docx>=1.0", "httpx>=0.27", "defusedxml>=0.7", "requests>=2.28"]
+dev = ["pytest>=8.3", "python-docx>=1.0", "httpx>=0.27", "requests>=2.28"]
 docx = ["python-docx>=1.0"]
 semantic = ["sentence-transformers>=3.0"]
 epub = ["ebooklib>=0.18,<1.0"]
 zvec = ["zvec>=0.1"]
-tools = ["defusedxml>=0.7", "requests>=2.28"]
+tools = ["requests>=2.28"]
 
 [project.urls]
 Homepage = "https://spitfire-cowboy.github.io/alcove/"

--- a/tests/test_govdata_congress.py
+++ b/tests/test_govdata_congress.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+import zipfile
+
+from alcove.govdata.congress import (
+    CONGRESS_SUMMARIES_COLLECTION,
+    ingest_billsum,
+    index_billsum_records,
+    load_billsum_records,
+    parse_billsum_xml,
+)
+
+GOVINFO_BILLSUM_XML = """
+<billSummaries>
+  <item congress="118" measure-type="hr" measure-number="42" originChamber="House" orig-publish-date="2024-01-10" update-date="2024-01-12">
+    <title>Open Archives Act</title>
+    <summary summary-id="id118hr42v10" currentChamber="HOUSE">
+      <action-date>2024-01-12</action-date>
+      <action-desc>Reported by committee</action-desc>
+      <summary-text><![CDATA[<p>To improve public access to legislative records.</p>]]></summary-text>
+    </summary>
+  </item>
+</billSummaries>
+""".strip()
+
+
+def test_parse_billsum_xml_handles_govinfo_items():
+    records = parse_billsum_xml(GOVINFO_BILLSUM_XML, source="govinfo.xml")
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["id"] == "bill-118-hr-42-summary-v10"
+    assert record["metadata"]["collection"] == CONGRESS_SUMMARIES_COLLECTION
+    assert record["metadata"]["bill_type"] == "hr"
+    assert record["metadata"]["action_desc"] == "Reported by committee"
+    assert record["metadata"]["source_format"] == "govinfo-billsum-xml"
+    assert "public access to legislative records" in record["document"]
+
+
+def test_load_billsum_records_reads_zip_and_jsonl(tmp_path):
+    archive_path = tmp_path / "billsum.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("BILLSUM/sample.xml", GOVINFO_BILLSUM_XML)
+
+    zipped = load_billsum_records(archive_path)
+    assert len(zipped) == 1
+    assert zipped[0]["metadata"]["source"].endswith("sample.xml")
+
+    jsonl_path = tmp_path / "summaries.jsonl"
+    jsonl_path.write_text(json.dumps(zipped[0]) + "\n", encoding="utf-8")
+    loaded = load_billsum_records(jsonl_path)
+    assert loaded == zipped
+
+
+def test_index_billsum_records_uses_requested_collection(monkeypatch):
+    captured = {}
+
+    class DummyEmbedder:
+        def embed(self, texts):
+            captured["embedded"] = list(texts)
+            return [[0.25, 0.5] for _ in texts]
+
+    class DummyBackend:
+        def add(self, ids, embeddings, documents, metadatas):
+            captured["ids"] = ids
+            captured["embeddings"] = embeddings
+            captured["documents"] = documents
+            captured["metadatas"] = metadatas
+
+    monkeypatch.setattr(
+        "alcove.govdata.congress._load_indexing_dependencies",
+        lambda: (lambda: DummyEmbedder(), lambda _embedder: DummyBackend()),
+    )
+
+    records = parse_billsum_xml(GOVINFO_BILLSUM_XML, source="sample.xml")
+    indexed = index_billsum_records(records, collection_name="public_congress")
+
+    assert indexed == 1
+    assert captured["ids"] == ["bill-118-hr-42-summary-v10"]
+    assert captured["metadatas"][0]["collection"] == "public_congress"
+
+
+def test_ingest_billsum_writes_normalized_jsonl(tmp_path, monkeypatch):
+    source_path = tmp_path / "sample.xml"
+    output_path = tmp_path / "summaries.jsonl"
+    source_path.write_text(GOVINFO_BILLSUM_XML, encoding="utf-8")
+
+    monkeypatch.setattr(
+        "alcove.govdata.congress.index_billsum_records",
+        lambda records, collection_name: len(list(records)),
+    )
+
+    indexed = ingest_billsum(
+        source=source_path,
+        collection_name="public_congress",
+        jsonl_out=output_path,
+    )
+
+    payload = output_path.read_text(encoding="utf-8")
+    assert indexed == 1
+    assert "public_congress" in payload

--- a/tests/test_govdata_congress.py
+++ b/tests/test_govdata_congress.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import json
 import zipfile
+from io import BytesIO
+
+import pytest
 
 from alcove.govdata.congress import (
     CONGRESS_SUMMARIES_COLLECTION,
@@ -9,6 +12,7 @@ from alcove.govdata.congress import (
     index_billsum_records,
     load_billsum_records,
     parse_billsum_xml,
+    write_jsonl,
 )
 
 GOVINFO_BILLSUM_XML = """
@@ -51,6 +55,169 @@ def test_load_billsum_records_reads_zip_and_jsonl(tmp_path):
     jsonl_path.write_text(json.dumps(zipped[0]) + "\n", encoding="utf-8")
     loaded = load_billsum_records(jsonl_path)
     assert loaded == zipped
+
+
+def test_load_billsum_records_handles_source_errors_and_directories(tmp_path):
+    with pytest.raises(ValueError, match="Provide"):
+        load_billsum_records()
+    with pytest.raises(FileNotFoundError):
+        load_billsum_records(tmp_path / "missing.xml")
+    unsupported = tmp_path / "billsum.txt"
+    unsupported.write_text("x", encoding="utf-8")
+    with pytest.raises(ValueError, match="Unsupported"):
+        load_billsum_records(unsupported)
+
+    directory = tmp_path / "source"
+    directory.mkdir()
+    (directory / "subdir").mkdir()
+    (directory / "ignore.txt").write_text("ignored", encoding="utf-8")
+    (directory / "sample.xml").write_text(GOVINFO_BILLSUM_XML, encoding="utf-8")
+    archive_path = directory / "nested.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("sample.xml", GOVINFO_BILLSUM_XML)
+
+    records = load_billsum_records(directory)
+    assert len(records) == 2
+
+
+def test_billsum_download_file(monkeypatch, tmp_path):
+    from alcove.govdata import congress
+
+    class FakeResponse:
+        def __enter__(self):
+            return BytesIO(b"downloaded")
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(congress.urllib.request, "urlopen", lambda url: FakeResponse())
+    destination = tmp_path / "nested" / "file.xml"
+
+    assert congress.download_file("https://www.govinfo.gov/example.xml", destination) == destination
+    assert destination.read_bytes() == b"downloaded"
+
+
+def test_load_billsum_records_source_url_uses_download(tmp_path, monkeypatch):
+    from alcove.govdata import congress
+
+    def fake_download(_url, destination):
+        destination.write_text(GOVINFO_BILLSUM_XML, encoding="utf-8")
+        return destination
+
+    monkeypatch.setattr(congress, "download_file", fake_download)
+
+    records = load_billsum_records(source_url="https://www.govinfo.gov/example/billsum.xml")
+
+    assert len(records) == 1
+
+
+def test_load_billsum_jsonl_skips_invalid_rows(tmp_path):
+    jsonl_path = tmp_path / "summaries.jsonl"
+    valid = {
+        "id": "ok",
+        "document": "text",
+        "metadata": {"source": "x.xml"},
+    }
+    jsonl_path.write_text(
+        "\n".join([
+            "",
+            "[]",
+            json.dumps({"id": "", "document": "text", "metadata": {}}),
+            json.dumps({"id": "missing-doc", "metadata": {}}),
+            json.dumps({"id": "missing-meta", "document": "text"}),
+            json.dumps(valid),
+        ]),
+        encoding="utf-8",
+    )
+
+    assert load_billsum_records(jsonl_path) == [valid]
+
+
+def test_parse_billsum_xml_handles_legacy_summary_nodes():
+    xml = """
+    <root>
+      <congress>117</congress>
+      <summary>
+        <billType>sjres</billType>
+        <billNumber>9</billNumber>
+        <title>Legacy Summary</title>
+        <version>v2</version>
+        <actionDate>2023-01-01</actionDate>
+        <text><![CDATA[<p>Legacy summary text.</p>]]></text>
+      </summary>
+      <summary>
+        <billType>hr</billType>
+        <billNumber>10</billNumber>
+      </summary>
+    </root>
+    """
+
+    records = parse_billsum_xml(xml, source="legacy.xml")
+
+    assert len(records) == 1
+    assert records[0]["id"] == "bill-117-sjres-9-summary-v2"
+    assert records[0]["metadata"]["date_issued"] == "2023-01-01"
+
+
+def test_parse_billsum_xml_handles_legacy_summary_without_title_and_missing_text():
+    xml = """
+    <root>
+      <summary>
+        <congress>117</congress>
+        <billType>hr</billType>
+        <billNumber>12</billNumber>
+        <summaryText>Summary without a title.</summaryText>
+      </summary>
+      <summary>
+        <congress>117</congress>
+        <billType>hr</billType>
+        <billNumber>13</billNumber>
+      </summary>
+    </root>
+    """
+
+    records = parse_billsum_xml(xml, source="legacy.xml")
+
+    assert len(records) == 1
+    assert records[0]["document"] == "Summary without a title."
+    assert records[0]["metadata"]["version"] == "legacy-1"
+
+
+def test_parse_billsum_xml_skips_invalid_items_and_uses_fallbacks():
+    xml = """
+    <billSummaries>
+      <item congress="" measure-type="hr" measure-number="1">
+        <summary><summary-text>missing congress</summary-text></summary>
+      </item>
+      <item congress="118" measure-type="s" measure-number="7">
+        <summary summary-id="summary-v5"><summary-text>Fallback title summary.</summary-text></summary>
+        <summary><summary-text></summary-text></summary>
+      </item>
+    </billSummaries>
+    """
+
+    records = parse_billsum_xml(xml, source="fallback.xml")
+
+    assert len(records) == 1
+    assert records[0]["id"] == "bill-118-s-7-summary-v5"
+    assert records[0]["metadata"]["title"] == "S 7"
+
+
+def test_billsum_helper_branches():
+    from defusedxml import ElementTree as ET
+    from alcove.govdata import congress
+
+    summary = ET.fromstring("<summary><version>Version 10!</version></summary>")
+    assert congress._extract_summary_version(summary, fallback_index=3) == "version10"
+    assert congress._extract_summary_text(summary) == ""
+    assert congress._normalize_bill_type(None) == ""
+    assert congress._normalize_version("!!!") == "v00"
+    assert congress._coerce_int("abc") is None
+    assert congress._load_indexing_dependencies()[0].__name__ == "get_embedder"
+
+
+def test_index_billsum_records_empty_returns_zero():
+    assert index_billsum_records([]) == 0
 
 
 def test_index_billsum_records_uses_requested_collection(monkeypatch):
@@ -100,3 +267,11 @@ def test_ingest_billsum_writes_normalized_jsonl(tmp_path, monkeypatch):
     payload = output_path.read_text(encoding="utf-8")
     assert indexed == 1
     assert "public_congress" in payload
+
+
+def test_write_jsonl_creates_parent_directory(tmp_path):
+    output = tmp_path / "nested" / "records.jsonl"
+    records = [{"id": "a", "document": "text", "metadata": {"source": "x"}}]
+
+    assert write_jsonl(records, output) == output
+    assert output.exists()

--- a/tests/test_govdata_congress_billstatus.py
+++ b/tests/test_govdata_congress_billstatus.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import json
 import zipfile
+from io import BytesIO
+
+import pytest
 
 from alcove.govdata.congress_billstatus import (
     CONGRESS_BILLSTATUS_COLLECTION,
@@ -106,6 +109,193 @@ def test_load_billstatus_records_reads_zip_and_jsonl(tmp_path):
     assert load_billstatus_records(source=jsonl_path) == zipped
 
 
+def test_load_billstatus_records_handles_source_errors_and_limits(tmp_path):
+    with pytest.raises(ValueError, match="Provide"):
+        load_billstatus_records()
+    with pytest.raises(FileNotFoundError):
+        load_billstatus_records(source=tmp_path / "missing.xml")
+    unsupported = tmp_path / "billstatus.txt"
+    unsupported.write_text("x", encoding="utf-8")
+    with pytest.raises(ValueError, match="Unsupported"):
+        load_billstatus_records(source=unsupported)
+
+    directory = tmp_path / "source"
+    directory.mkdir()
+    (directory / "subdir").mkdir()
+    (directory / "ignore.txt").write_text("ignored", encoding="utf-8")
+    (directory / "one.xml").write_text(SAMPLE_BILLSTATUS_XML, encoding="utf-8")
+    archive_path = directory / "two.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("BILLSTATUS-118hr43.xml", SAMPLE_BILLSTATUS_XML)
+
+    records = load_billstatus_records(source=directory, limit=1)
+    assert len(records) == 1
+
+
+def test_billstatus_download_file(monkeypatch, tmp_path):
+    from alcove.govdata import congress_billstatus
+
+    class FakeResponse:
+        def __enter__(self):
+            return BytesIO(b"downloaded")
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(congress_billstatus.urllib.request, "urlopen", lambda url: FakeResponse())
+    destination = tmp_path / "nested" / "file.xml"
+
+    assert congress_billstatus.download_file("https://www.govinfo.gov/example.xml", destination) == destination
+    assert destination.read_bytes() == b"downloaded"
+
+
+def test_load_billstatus_records_source_url_uses_download(tmp_path, monkeypatch):
+    from alcove.govdata import congress_billstatus
+
+    def fake_download(_url, destination):
+        destination.write_text(SAMPLE_BILLSTATUS_XML, encoding="utf-8")
+        return destination
+
+    monkeypatch.setattr(congress_billstatus, "download_file", fake_download)
+
+    records = load_billstatus_records(source_url="https://www.govinfo.gov/example/billstatus.xml")
+
+    assert len(records) == 1
+
+
+def test_load_billstatus_jsonl_skips_invalid_rows_and_limits(tmp_path):
+    jsonl_path = tmp_path / "billstatus.jsonl"
+    valid = {"id": "ok", "document": "text", "metadata": {"source": "x.xml"}}
+    second = {"id": "ok-2", "document": "text 2", "metadata": {"source": "y.xml"}}
+    jsonl_path.write_text(
+        "\n".join([
+            "",
+            "[]",
+            json.dumps({"id": "", "document": "text", "metadata": {}}),
+            json.dumps({"id": "missing-doc", "metadata": {}}),
+            json.dumps(valid),
+            json.dumps(second),
+        ]),
+        encoding="utf-8",
+    )
+
+    assert load_billstatus_records(source=jsonl_path, limit=1) == [valid]
+
+
+def test_billstatus_zip_skips_non_xml_and_honors_limit(tmp_path):
+    archive_path = tmp_path / "billstatus.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("README.txt", "ignore")
+        archive.writestr("BILLSTATUS-118hr42.xml", SAMPLE_BILLSTATUS_XML)
+        archive.writestr("BILLSTATUS-118hr43.xml", SAMPLE_BILLSTATUS_XML)
+
+    records = load_billstatus_records(source=archive_path, limit=1)
+
+    assert len(records) == 1
+
+
+def test_parse_billstatus_xml_handles_empty_and_fallback_title():
+    assert parse_billstatus_xml("<root />") == []
+    xml = """
+    <billStatus>
+      <bill>
+        <number>44</number>
+        <type>S.</type>
+        <congress>118</congress>
+        <title>Fallback Senate Bill</title>
+        <originChamber>Senate</originChamber>
+      </bill>
+    </billStatus>
+    """
+
+    records = parse_billstatus_xml(xml, source="fallback.xml")
+
+    assert len(records) == 1
+    assert records[0]["metadata"]["title"] == "Fallback Senate Bill"
+    assert records[0]["metadata"]["url"].endswith("/senate-bill/44")
+    assert records[0]["metadata"]["status"] == "unknown"
+
+
+def test_parse_billstatus_xml_handles_title_item_fallback_and_missing_required():
+    invalid = """
+    <billStatus>
+      <bill>
+        <number>45</number>
+        <type>HR</type>
+      </bill>
+    </billStatus>
+    """
+    assert parse_billstatus_xml(invalid) == []
+
+    xml = """
+    <billStatus>
+      <bill>
+        <number>46</number>
+        <type>HR</type>
+        <congress>118</congress>
+        <titles>
+          <note>ignored</note>
+          <item><titleType>Short Title</titleType><title>Short title fallback</title></item>
+        </titles>
+        <actions>
+          <item><text>Action without date.</text></item>
+        </actions>
+      </bill>
+    </billStatus>
+    """
+
+    records = parse_billstatus_xml(xml, source="fallback.xml")
+
+    assert len(records) == 1
+    assert records[0]["metadata"]["title"] == "Short title fallback"
+    assert "Action without date." in records[0]["document"]
+
+
+def test_billstatus_sitemap_loader(monkeypatch):
+    from alcove.govdata import congress_billstatus
+
+    class FakeResponse:
+        def __init__(self, body):
+            self.body = body
+
+        def read(self):
+            return self.body.encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    sitemap = """
+    <urlset>
+      <url><loc>https://www.govinfo.gov/bulkdata/BILLSTATUS/118/hr/BILLSTATUS-118hr42.xml</loc></url>
+      <url><loc>https://www.govinfo.gov/bulkdata/BILLSTATUS/118/hr/readme.txt</loc></url>
+      <url><loc>https://www.govinfo.gov/bulkdata/BILLSTATUS/118/hr/BILLSTATUS-118hr43.xml</loc></url>
+    </urlset>
+    """
+    calls = []
+
+    def fake_urlopen(url, timeout=30):
+        calls.append(url)
+        if url.endswith("sitemap.xml"):
+            return FakeResponse(sitemap)
+        if url.endswith("43.xml"):
+            raise OSError("skip this one")
+        return FakeResponse(SAMPLE_BILLSTATUS_XML)
+
+    monkeypatch.setattr(congress_billstatus.urllib.request, "urlopen", fake_urlopen)
+
+    records = load_billstatus_records(congress=118, bill_type="HR", limit=1)
+
+    assert len(records) == 1
+    assert calls[0].endswith("/118hr/sitemap.xml")
+
+
+def test_index_billstatus_records_empty_returns_zero():
+    assert index_billstatus_records([]) == 0
+
+
 def test_index_billstatus_records_uses_requested_collection(monkeypatch):
     captured = {}
 
@@ -153,3 +343,30 @@ def test_ingest_billstatus_writes_normalized_jsonl(tmp_path, monkeypatch):
     payload = json.loads(output_path.read_text(encoding="utf-8").splitlines()[0])
     assert count == 1
     assert payload["metadata"]["collection"] == "public_billstatus"
+
+
+def test_status_derivation_branches():
+    from alcove.govdata import congress_billstatus
+
+    assert congress_billstatus._derive_status("Became Public Law", []) == "enacted"
+    assert congress_billstatus._derive_status("Passed Senate", []) == "passed-senate"
+    assert congress_billstatus._derive_status("Passed House", []) == "passed-house"
+    assert congress_billstatus._derive_status("Failed passage", []) == "failed"
+    assert congress_billstatus._derive_status("Vetoed by President", []) == "vetoed"
+    assert congress_billstatus._derive_status("Referred to committee", []) == "referred"
+
+
+def test_billstatus_helper_branches():
+    from defusedxml import ElementTree as ET
+    from alcove.govdata import congress_billstatus
+
+    assert congress_billstatus._build_congress_url("118", "hjres", "1", "Unknown").endswith("/house-bill/1")
+    assert congress_billstatus._find_all(None, "item") == []
+    assert congress_billstatus._first_node(None, "bill") is None
+    assert congress_billstatus._first_child_node(None, "item") is None
+    assert congress_billstatus._direct_child(None, "latestAction") is None
+    assert congress_billstatus._text(None, "title") is None
+    assert congress_billstatus._text_nested(None, "policyArea", "name") is None
+    assert congress_billstatus._normalize_bill_type(None) == ""
+    assert congress_billstatus._load_indexing_dependencies()[0].__name__ == "get_embedder"
+    assert congress_billstatus._extract_display_title(ET.fromstring("<bill><titles><note /></titles></bill>")) is None

--- a/tests/test_govdata_congress_billstatus.py
+++ b/tests/test_govdata_congress_billstatus.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+import zipfile
+
+from alcove.govdata.congress_billstatus import (
+    CONGRESS_BILLSTATUS_COLLECTION,
+    ingest_billstatus,
+    index_billstatus_records,
+    load_billstatus_records,
+    parse_billstatus_xml,
+    write_jsonl,
+)
+
+SAMPLE_BILLSTATUS_XML = """<?xml version="1.0" encoding="utf-8"?>
+<billStatus>
+  <bill>
+    <number>42</number>
+    <updateDate>2024-01-15T12:00:00Z</updateDate>
+    <originChamber>House</originChamber>
+    <type>HR</type>
+    <introducedDate>2023-01-10</introducedDate>
+    <congress>118</congress>
+    <legislationUrl>https://www.congress.gov/bill/118th-congress/house-bill/42</legislationUrl>
+    <titles>
+      <item>
+        <titleType>Display Title</titleType>
+        <title>Open Archives Act</title>
+      </item>
+    </titles>
+    <sponsors>
+      <item>
+        <bioguideId>S001176</bioguideId>
+        <fullName>Rep. Smith, Jane [D-CA-1]</fullName>
+        <party>D</party>
+        <state>CA</state>
+      </item>
+    </sponsors>
+    <cosponsors>
+      <item>
+        <fullName>Rep. Jones, Bob [R-TX-5]</fullName>
+      </item>
+    </cosponsors>
+    <committees>
+      <item>
+        <name>Judiciary Committee</name>
+      </item>
+    </committees>
+    <policyArea>
+      <name>Government Operations and Politics</name>
+    </policyArea>
+    <actions>
+      <item>
+        <actionDate>2023-01-10</actionDate>
+        <text>Introduced in House</text>
+      </item>
+      <item>
+        <actionDate>2023-03-15</actionDate>
+        <text>Subcommittee Hearings Held.</text>
+      </item>
+    </actions>
+    <latestAction>
+      <actionDate>2023-03-15</actionDate>
+      <text>Subcommittee Hearings Held.</text>
+    </latestAction>
+    <relatedBills>
+      <item>
+        <number>100</number>
+        <type>S</type>
+        <congress>118</congress>
+      </item>
+    </relatedBills>
+  </bill>
+</billStatus>
+""".strip()
+
+
+def test_parse_billstatus_xml_extracts_retrieval_record():
+    records = parse_billstatus_xml(SAMPLE_BILLSTATUS_XML, source="sample.xml")
+
+    assert len(records) == 1
+    record = records[0]
+    metadata = record["metadata"]
+    assert record["id"] == "billstatus-118-hr-42"
+    assert metadata["collection"] == CONGRESS_BILLSTATUS_COLLECTION
+    assert metadata["title"] == "Open Archives Act"
+    assert metadata["sponsor_name"] == "Rep. Smith, Jane [D-CA-1]"
+    assert metadata["cosponsor_count"] == "1"
+    assert metadata["committees"] == "Judiciary Committee"
+    assert metadata["policy_area"] == "Government Operations and Politics"
+    assert metadata["status"] == "active"
+    assert metadata["related_bill_count"] == "1"
+    assert "Judiciary Committee" in record["document"]
+
+
+def test_load_billstatus_records_reads_zip_and_jsonl(tmp_path):
+    archive_path = tmp_path / "billstatus.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr("BILLSTATUS-118hr42.xml", SAMPLE_BILLSTATUS_XML)
+
+    zipped = load_billstatus_records(source=archive_path)
+    assert len(zipped) == 1
+
+    jsonl_path = tmp_path / "billstatus.jsonl"
+    write_jsonl(zipped, jsonl_path)
+    assert load_billstatus_records(source=jsonl_path) == zipped
+
+
+def test_index_billstatus_records_uses_requested_collection(monkeypatch):
+    captured = {}
+
+    class DummyEmbedder:
+        def embed(self, texts):
+            captured["embedded"] = list(texts)
+            return [[0.1, 0.2] for _ in texts]
+
+    class DummyBackend:
+        def add(self, ids, embeddings, documents, metadatas):
+            captured["ids"] = ids
+            captured["embeddings"] = embeddings
+            captured["documents"] = documents
+            captured["metadatas"] = metadatas
+
+    monkeypatch.setattr(
+        "alcove.govdata.congress_billstatus._load_indexing_dependencies",
+        lambda: (lambda: DummyEmbedder(), lambda _embedder: DummyBackend()),
+    )
+
+    records = parse_billstatus_xml(SAMPLE_BILLSTATUS_XML, source="sample.xml")
+    indexed = index_billstatus_records(records, collection_name="public_billstatus")
+
+    assert indexed == 1
+    assert captured["ids"] == ["billstatus-118-hr-42"]
+    assert captured["metadatas"][0]["collection"] == "public_billstatus"
+
+
+def test_ingest_billstatus_writes_normalized_jsonl(tmp_path, monkeypatch):
+    source_path = tmp_path / "BILLSTATUS-118hr42.xml"
+    output_path = tmp_path / "billstatus.jsonl"
+    source_path.write_text(SAMPLE_BILLSTATUS_XML, encoding="utf-8")
+
+    monkeypatch.setattr(
+        "alcove.govdata.congress_billstatus.index_billstatus_records",
+        lambda records, collection_name: len(list(records)),
+    )
+
+    count = ingest_billstatus(
+        source=source_path,
+        collection_name="public_billstatus",
+        jsonl_out=output_path,
+    )
+
+    payload = json.loads(output_path.read_text(encoding="utf-8").splitlines()[0])
+    assert count == 1
+    assert payload["metadata"]["collection"] == "public_billstatus"


### PR DESCRIPTION
## Summary

- Adds public GovInfo BILLSUM loaders that normalize bill summaries into Alcove retrieval records.
- Adds public GovInfo BILLSTATUS loaders that normalize bill status XML into retrieval records.
- Adds focused parser/indexing tests and updates CHANGELOG/ROADMAP.
- Moves `defusedxml` into base dependencies because the public data modules import it directly.

## Safety and privacy

- Public data modules only; no production UI, deployment scripts, watchdogs, Sentry, DNS, registrar, or private repository references.
- Network use is explicit: callers provide a source URL or congress/bill type sitemap inputs.

## Tests

- python3 -m pytest tests/test_govdata_congress.py tests/test_govdata_congress_billstatus.py -q
- python3 -m compileall alcove/govdata
- python3 -m pytest -q
