### PR TITLE
Add Mirrulations public data loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to alcove-search.
 
+## [Unreleased]
+
+- Add a Mirrulations public regulatory data loader for local `text-*` corpus subsets.
+
 ## [0.3.0] - 2026-03-07
 
 - Add theme toggle, fix WCAG AA contrast, update accessibility docs

--- a/alcove/cli.py
+++ b/alcove/cli.py
@@ -130,6 +130,18 @@ def cmd_seed_demo(_args):
         subprocess.check_call([sys.executable, str(script_path)])
 
 
+def cmd_mirrulations_demo(args):
+    from alcove.govdata.mirrulations import ingest_mirrulations
+
+    count = ingest_mirrulations(
+        source=args.source,
+        agencies=args.agency,
+        collection_name=args.collection,
+        jsonl_out=args.jsonl_out,
+    )
+    print(f"indexed {count} Mirrulations records into {args.collection}")
+
+
 def _add_search_parser(sub, name, hidden=False):
     """Add a search/query subparser. Used for both the primary and alias."""
     help_text = argparse.SUPPRESS if hidden else "Search local index"
@@ -187,6 +199,35 @@ def main():
     # seed-demo
     p_seed = sub.add_parser("seed-demo", help="Fetch and index demo corpus")
     p_seed.set_defaults(func=cmd_seed_demo)
+
+    # mirrulations-demo
+    p_mirrulations = sub.add_parser(
+        "mirrulations-demo",
+        help="Ingest a local Mirrulations text subset into a dedicated collection",
+    )
+    p_mirrulations.add_argument(
+        "source",
+        nargs="?",
+        default=None,
+        help="Local Mirrulations root, agency, docket, or text-* path",
+    )
+    p_mirrulations.add_argument(
+        "--agency",
+        action="append",
+        default=[],
+        help="Optional agency filter; repeat for multiple agencies",
+    )
+    p_mirrulations.add_argument(
+        "--collection",
+        default="mirrulations_docs",
+        help="Target collection metadata value (default: mirrulations_docs)",
+    )
+    p_mirrulations.add_argument(
+        "--jsonl-out",
+        default=None,
+        help="Optional path to write normalized records as JSONL",
+    )
+    p_mirrulations.set_defaults(func=cmd_mirrulations_demo)
 
     # plugins
     p_plugins = sub.add_parser("plugins", help="List installed plugins")

--- a/alcove/govdata/mirrulations.py
+++ b/alcove/govdata/mirrulations.py
@@ -317,7 +317,7 @@ def _extract_entity_id(payload: dict, *, fallback: str) -> str:
 
 def _agency_for_text_dir(text_dir: Path) -> str:
     try:
-        return text_dir.parent.parent.name
+        return text_dir.parent.parent.name or "UNKNOWN"
     except IndexError:
         return "UNKNOWN"
 

--- a/alcove/govdata/mirrulations.py
+++ b/alcove/govdata/mirrulations.py
@@ -1,0 +1,365 @@
+"""Mirrulations public regulatory data ingest helpers."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable
+from html import unescape
+from pathlib import Path
+
+MIRRULATIONS_COLLECTION = "mirrulations_docs"
+TAG_STRIPPER = re.compile(r"<[^>]+>")
+WHITESPACE = re.compile(r"\s+")
+
+
+def ingest_mirrulations(
+    source: str | Path | None = None,
+    *,
+    agencies: Iterable[str] | None = None,
+    collection_name: str = MIRRULATIONS_COLLECTION,
+    jsonl_out: str | Path | None = None,
+) -> int:
+    records = _apply_collection_name(
+        load_mirrulations_records(source=source, agencies=agencies),
+        collection_name=collection_name,
+    )
+    if jsonl_out is not None:
+        write_jsonl(records, jsonl_out)
+    return index_mirrulations_records(records, collection_name=collection_name)
+
+
+def load_mirrulations_records(
+    source: str | Path | None = None,
+    *,
+    agencies: Iterable[str] | None = None,
+) -> list[dict]:
+    if not source:
+        raise ValueError("Provide a local Mirrulations directory path.")
+
+    path = Path(source)
+    if not path.exists():
+        raise FileNotFoundError(path)
+
+    agency_filter = {item.strip().upper() for item in (agencies or []) if item and item.strip()}
+    records: list[dict] = []
+    for text_dir in _discover_text_directories(path, agency_filter=agency_filter):
+        records.extend(_load_text_directory(text_dir))
+    return records
+
+
+def index_mirrulations_records(
+    records: Iterable[dict],
+    *,
+    collection_name: str = MIRRULATIONS_COLLECTION,
+) -> int:
+    materialized = _apply_collection_name(records, collection_name=collection_name)
+    if not materialized:
+        return 0
+
+    get_embedder, get_backend = _load_indexing_dependencies()
+    embedder = get_embedder()
+    backend = get_backend(embedder)
+    documents = [record["document"] for record in materialized]
+    metadatas = [dict(record["metadata"]) for record in materialized]
+
+    backend.add(
+        ids=[record["id"] for record in materialized],
+        embeddings=embedder.embed(documents),
+        documents=documents,
+        metadatas=metadatas,
+    )
+    return len(materialized)
+
+
+def write_jsonl(records: Iterable[dict], output_path: str | Path) -> Path:
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as fh:
+        for record in records:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+    return output_path
+
+
+def _load_indexing_dependencies():
+    from alcove.index.backend import get_backend
+    from alcove.index.embedder import get_embedder
+
+    return get_embedder, get_backend
+
+
+def _apply_collection_name(records: Iterable[dict], *, collection_name: str) -> list[dict]:
+    normalized = []
+    for record in records:
+        metadata = dict(record["metadata"])
+        metadata["collection"] = collection_name
+        normalized.append(
+            {
+                "id": record["id"],
+                "document": record["document"],
+                "metadata": metadata,
+            }
+        )
+    return normalized
+
+
+def _discover_text_directories(path: Path, *, agency_filter: set[str]) -> list[Path]:
+    if path.is_dir() and path.name.startswith("text-"):
+        candidates = [path]
+    else:
+        candidates = [candidate for candidate in path.rglob("text-*") if candidate.is_dir()]
+
+    discovered = []
+    for candidate in sorted(candidates):
+        agency = _agency_for_text_dir(candidate)
+        if agency_filter and agency.upper() not in agency_filter:
+            continue
+        discovered.append(candidate)
+    return discovered
+
+
+def _load_text_directory(text_dir: Path) -> list[dict]:
+    docket_id = text_dir.name.removeprefix("text-")
+    agency = _agency_for_text_dir(text_dir)
+    records: list[dict] = []
+
+    docket_json = text_dir / "docket" / f"{docket_id}.json"
+    if docket_json.exists():
+        record = _build_docket_record(docket_json, agency=agency, docket_id=docket_id)
+        if record:
+            records.append(record)
+
+    records.extend(_load_document_records(text_dir, agency=agency, docket_id=docket_id))
+    records.extend(_load_comment_records(text_dir, agency=agency, docket_id=docket_id))
+    records.extend(_load_attachment_records(text_dir, agency=agency, docket_id=docket_id, scope="documents"))
+    records.extend(_load_attachment_records(text_dir, agency=agency, docket_id=docket_id, scope="comments"))
+    return records
+
+
+def _load_document_records(text_dir: Path, *, agency: str, docket_id: str) -> list[dict]:
+    directory = text_dir / "documents"
+    records: list[dict] = []
+    for json_path in sorted(directory.glob("*.json")):
+        payload = _read_json(json_path)
+        document_id = _extract_entity_id(payload, fallback=json_path.stem)
+        attributes = _extract_attributes(payload)
+        title = _first_nonempty(
+            _clean_text(attributes.get("title")),
+            _clean_text(attributes.get("objectTitle")),
+            document_id,
+        )
+        html_path = directory / f"{json_path.stem}_content.htm"
+        body = _first_nonempty(
+            _clean_text(html_path.read_text(encoding="utf-8", errors="ignore")) if html_path.exists() else "",
+            _clean_text(attributes.get("summary")),
+            _clean_text(attributes.get("abstract")),
+        )
+        if not body:
+            continue
+
+        records.append(
+            {
+                "id": f"document-{document_id}",
+                "document": _compose_record_text(title, body),
+                "metadata": {
+                    "source": str(json_path),
+                    "collection": MIRRULATIONS_COLLECTION,
+                    "agency": agency,
+                    "docket_id": docket_id,
+                    "mirrulations_id": document_id,
+                    "entry_type": "document",
+                    "title": title,
+                    "document_type": _first_nonempty(attributes.get("documentType"), attributes.get("category"), ""),
+                    "posted_date": _first_nonempty(attributes.get("postedDate"), attributes.get("modifyDate"), ""),
+                    "url": _regulations_url(document_id, entry_type="document"),
+                    "source_format": "mirrulations-document-json",
+                },
+            }
+        )
+    return records
+
+
+def _load_comment_records(text_dir: Path, *, agency: str, docket_id: str) -> list[dict]:
+    directory = text_dir / "comments"
+    records: list[dict] = []
+    for json_path in sorted(directory.glob("*.json")):
+        payload = _read_json(json_path)
+        comment_id = _extract_entity_id(payload, fallback=json_path.stem)
+        attributes = _extract_attributes(payload)
+        body = _first_nonempty(
+            _clean_text(attributes.get("comment")),
+            _clean_text(attributes.get("commentText")),
+        )
+        if not body:
+            continue
+
+        title = _first_nonempty(
+            _clean_text(attributes.get("title")),
+            _clean_text(attributes.get("organization")),
+            comment_id,
+        )
+        records.append(
+            {
+                "id": f"comment-{comment_id}",
+                "document": _compose_record_text(title, body),
+                "metadata": {
+                    "source": str(json_path),
+                    "collection": MIRRULATIONS_COLLECTION,
+                    "agency": agency,
+                    "docket_id": docket_id,
+                    "mirrulations_id": comment_id,
+                    "entry_type": "comment",
+                    "title": title,
+                    "comment_on": attributes.get("commentOn") or "",
+                    "posted_date": _first_nonempty(attributes.get("postedDate"), attributes.get("modifyDate"), ""),
+                    "url": _regulations_url(comment_id, entry_type="document"),
+                    "source_format": "mirrulations-comment-json",
+                },
+            }
+        )
+    return records
+
+
+def _load_attachment_records(text_dir: Path, *, agency: str, docket_id: str, scope: str) -> list[dict]:
+    records: list[dict] = []
+    extracted_root = text_dir / f"{scope}_extracted_text"
+    if not extracted_root.exists():
+        return records
+
+    scope_name = "document" if scope == "documents" else "comment"
+    for tool_dir in sorted(path for path in extracted_root.iterdir() if path.is_dir()):
+        for txt_path in sorted(tool_dir.glob("*.txt")):
+            body = _clean_text(txt_path.read_text(encoding="utf-8", errors="ignore"))
+            if not body:
+                continue
+
+            parent_id = _parent_id_for_attachment(txt_path.stem)
+            title = f"{parent_id} attachment text"
+            records.append(
+                {
+                    "id": f"attachment-{scope_name}-{txt_path.stem}",
+                    "document": _compose_record_text(title, body),
+                    "metadata": {
+                        "source": str(txt_path),
+                        "collection": MIRRULATIONS_COLLECTION,
+                        "agency": agency,
+                        "docket_id": docket_id,
+                        "mirrulations_id": txt_path.stem,
+                        "entry_type": "attachment",
+                        "attachment_scope": scope_name,
+                        "parent_id": parent_id,
+                        "extraction_tool": tool_dir.name,
+                        "title": title,
+                        "url": _regulations_url(parent_id, entry_type="document"),
+                        "source_format": f"mirrulations-{scope_name}-attachment-text",
+                    },
+                }
+            )
+    return records
+
+
+def _build_docket_record(json_path: Path, *, agency: str, docket_id: str) -> dict | None:
+    payload = _read_json(json_path)
+    attributes = _extract_attributes(payload)
+    title = _first_nonempty(_clean_text(attributes.get("title")), docket_id)
+    body = _first_nonempty(
+        _clean_text(attributes.get("summary")),
+        _clean_text(attributes.get("description")),
+        _clean_text(attributes.get("keywords")),
+        title,
+    )
+    if not body:
+        return None
+
+    return {
+        "id": f"docket-{docket_id}",
+        "document": _compose_record_text(title, body),
+        "metadata": {
+            "source": str(json_path),
+            "collection": MIRRULATIONS_COLLECTION,
+            "agency": agency,
+            "docket_id": docket_id,
+            "mirrulations_id": docket_id,
+            "entry_type": "docket",
+            "title": title,
+            "posted_date": _first_nonempty(attributes.get("postedDate"), attributes.get("modifyDate"), ""),
+            "url": _regulations_url(docket_id, entry_type="docket"),
+            "source_format": "mirrulations-docket-json",
+        },
+    }
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8", errors="ignore"))
+
+
+def _extract_attributes(payload: dict) -> dict:
+    if isinstance(payload.get("data"), dict):
+        attributes = payload["data"].get("attributes")
+        if isinstance(attributes, dict):
+            return attributes
+    attributes = payload.get("attributes")
+    if isinstance(attributes, dict):
+        return attributes
+    return {}
+
+
+def _extract_entity_id(payload: dict, *, fallback: str) -> str:
+    if isinstance(payload.get("data"), dict):
+        value = payload["data"].get("id")
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    value = payload.get("id")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return fallback
+
+
+def _agency_for_text_dir(text_dir: Path) -> str:
+    try:
+        return text_dir.parent.parent.name
+    except IndexError:
+        return "UNKNOWN"
+
+
+def _regulations_url(entry_id: str, *, entry_type: str) -> str:
+    base = "https://www.regulations.gov"
+    if entry_type == "docket":
+        return f"{base}/docket/{entry_id}"
+    return f"{base}/document/{entry_id}"
+
+
+def _parent_id_for_attachment(stem: str) -> str:
+    for suffix in ("_content_extracted", "_extracted"):
+        if stem.endswith(suffix):
+            stem = stem[: -len(suffix)]
+            break
+
+    if "_attachment_" in stem:
+        return stem.split("_attachment_", 1)[0]
+    if stem.endswith("_content"):
+        return stem[: -len("_content")]
+    return stem
+
+
+def _compose_record_text(title: str, body: str) -> str:
+    title = _clean_text(title)
+    body = _clean_text(body)
+    if title and body and body != title:
+        return f"{title}\n\n{body}"
+    return title or body
+
+
+def _first_nonempty(*values: str | None) -> str:
+    for value in values:
+        if value and str(value).strip():
+            return str(value).strip()
+    return ""
+
+
+def _clean_text(value: str | None) -> str:
+    if not value:
+        return ""
+    text = unescape(str(value))
+    text = TAG_STRIPPER.sub(" ", text)
+    return WHITESPACE.sub(" ", text).strip()

--- a/docs/MIRRULATIONS_CORPUS.md
+++ b/docs/MIRRULATIONS_CORPUS.md
@@ -1,0 +1,42 @@
+# Mirrulations Public Data Loader
+
+Mirrulations publishes public Regulations.gov data in a shape that is useful for testing Alcove against real regulatory records. Alcove supports local Mirrulations `text-*` directories as a public-data loader.
+
+The loader reads only files already present on local disk. It does not download data, call hosted services, or require credentials.
+
+## Supported Inputs
+
+Point `alcove mirrulations-demo` at a Mirrulations root, agency directory, docket directory, or direct `text-<docket>` directory. It normalizes:
+
+- `docket/*.json` into one retrieval record per docket
+- `documents/*.json` plus matching `documents/*_content.htm` into one retrieval record per document
+- `comments/*.json` into one retrieval record per public comment
+- `documents_extracted_text/*/*.txt` and `comments_extracted_text/*/*.txt` into one retrieval record per extracted attachment text file
+
+Binary attachment files are out of scope for this loader. If you want attachment content indexed, provide extracted `.txt` files in the Mirrulations text tree.
+
+## Usage
+
+Prepare a local text-only Mirrulations subset outside Alcove, then index it:
+
+```bash
+alcove mirrulations-demo data/raw/mirrulations --agency EPA --jsonl-out data/processed/mirrulations.jsonl
+```
+
+By default, records are tagged with the `mirrulations_docs` collection metadata value:
+
+```bash
+alcove search "power plant emissions limits" --mode hybrid
+```
+
+Use `--collection` to tag records for a different collection-aware workflow:
+
+```bash
+alcove mirrulations-demo data/raw/mirrulations --collection regulatory_test_docs
+```
+
+## Notes
+
+- Field coverage varies by docket, so the loader skips records that do not contain searchable text.
+- Agency filters are case-insensitive and can be repeated.
+- Source metadata points to local file paths and public Regulations.gov URLs derived from docket, document, and comment identifiers.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,6 +20,8 @@ This is the foundation. Everything below builds on it.
 
 **Streaming ingest.** Watch a directory and re-index on change. The current pipeline is batch-oriented: you run `alcove ingest`, it processes everything. Streaming mode keeps the index current without manual intervention.
 
+**Public data loaders.** Domain-specific loaders should stay separate from the core ingest pipeline unless their format is generally useful. The Mirrulations loader follows that path for local `text-*` regulatory data subsets from public Regulations.gov mirrors.
+
 ## Mid-term
 
 **Cross-modal indexing.** Audio transcription, image OCR, video keyframe extraction. The pipeline architecture already separates extraction from embedding; new modalities plug in as extractors that produce text chunks from non-text sources. Bioacoustics and field recordings are a motivating use case, not an afterthought.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,7 @@ def test_alcove_help_exits_zero():
     # search is the primary command; query is a hidden alias
     assert "search" in result.stdout
     assert "status" in result.stdout
+    assert "mirrulations-demo" in result.stdout
 
 
 def test_alcove_query_alias_still_works():
@@ -23,6 +24,16 @@ def test_alcove_query_alias_still_works():
     )
     assert result.returncode == 0
     assert "--k" in result.stdout
+
+
+def test_alcove_mirrulations_demo_help():
+    result = subprocess.run(
+        [sys.executable, "-m", "alcove", "mirrulations-demo", "--help"],
+        capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    assert "--agency" in result.stdout
+    assert "--jsonl-out" in result.stdout
 
 
 def test_alcove_version():

--- a/tests/test_govdata_mirrulations.py
+++ b/tests/test_govdata_mirrulations.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from alcove.govdata.mirrulations import (
+    MIRRULATIONS_COLLECTION,
+    ingest_mirrulations,
+    index_mirrulations_records,
+    load_mirrulations_records,
+)
+
+
+def test_load_mirrulations_records_normalizes_text_tree(tmp_path):
+    text_dir = _make_text_tree(tmp_path, agency="EPA", docket_id="EPA-HQ-OAR-2023-0534")
+
+    records = load_mirrulations_records(text_dir.parent.parent)
+
+    assert len(records) == 5
+    ids = {record["id"] for record in records}
+    assert "docket-EPA-HQ-OAR-2023-0534" in ids
+    assert "document-EPA-HQ-OAR-2023-0534-0001" in ids
+    assert "comment-EPA-HQ-OAR-2023-0534-0002" in ids
+    assert "attachment-document-EPA-HQ-OAR-2023-0534-0001_content_extracted" in ids
+    assert "attachment-comment-EPA-HQ-OAR-2023-0534-0002_attachment_1_extracted" in ids
+
+    comment = next(record for record in records if record["metadata"]["entry_type"] == "comment")
+    assert "This proposal improves public health." in comment["document"]
+    assert "<p>" not in comment["document"]
+    assert comment["metadata"]["agency"] == "EPA"
+    assert comment["metadata"]["docket_id"] == "EPA-HQ-OAR-2023-0534"
+    assert comment["metadata"]["url"] == "https://www.regulations.gov/document/EPA-HQ-OAR-2023-0534-0002"
+
+
+def test_load_mirrulations_records_filters_agencies(tmp_path):
+    _make_text_tree(tmp_path, agency="EPA", docket_id="EPA-HQ-OAR-2023-0534")
+    _make_text_tree(tmp_path, agency="SEC", docket_id="SEC-2024-0007")
+
+    records = load_mirrulations_records(tmp_path, agencies=["epa"])
+
+    assert records
+    assert all(record["metadata"]["agency"] == "EPA" for record in records)
+
+
+def test_load_mirrulations_records_handles_source_errors_and_direct_text_dir(tmp_path):
+    with pytest.raises(ValueError, match="Provide"):
+        load_mirrulations_records()
+    with pytest.raises(FileNotFoundError):
+        load_mirrulations_records(tmp_path / "missing")
+
+    text_dir = _make_text_tree(tmp_path, agency="EPA", docket_id="EPA-HQ-OAR-2023-0534")
+    records = load_mirrulations_records(text_dir)
+
+    assert len(records) == 5
+
+
+def test_load_mirrulations_records_skips_missing_text(tmp_path):
+    text_dir = tmp_path / "EPA" / "EPA-HQ-OAR-2023-0534" / "text-EPA-HQ-OAR-2023-0534"
+    (text_dir / "documents").mkdir(parents=True)
+    (text_dir / "comments").mkdir()
+    _write_json(
+        text_dir / "documents" / "empty.json",
+        {"data": {"id": "empty-doc", "attributes": {"title": "Empty"}}},
+    )
+    _write_json(
+        text_dir / "comments" / "empty.json",
+        {"data": {"id": "empty-comment", "attributes": {"organization": "Public Org"}}},
+    )
+
+    assert load_mirrulations_records(tmp_path) == []
+
+
+def test_index_mirrulations_records_tags_requested_collection(monkeypatch):
+    captured = {}
+
+    class DummyEmbedder:
+        def embed(self, texts):
+            captured["embedded"] = list(texts)
+            return [[0.125, 0.25] for _ in texts]
+
+    class DummyBackend:
+        def add(self, ids, embeddings, documents, metadatas):
+            captured["ids"] = ids
+            captured["embeddings"] = embeddings
+            captured["documents"] = documents
+            captured["metadatas"] = metadatas
+
+    monkeypatch.setattr(
+        "alcove.govdata.mirrulations._load_indexing_dependencies",
+        lambda: (lambda: DummyEmbedder(), lambda embedder: DummyBackend()),
+    )
+
+    records = [
+        {
+            "id": "comment-EPA-HQ-OAR-2023-0534-0002",
+            "document": "EPA comment\n\nThis proposal improves public health.",
+            "metadata": {
+                "collection": MIRRULATIONS_COLLECTION,
+                "source": "comment.json",
+                "entry_type": "comment",
+            },
+        }
+    ]
+    indexed = index_mirrulations_records(records, collection_name="regulatory_test_docs")
+
+    assert indexed == 1
+    assert captured["ids"] == ["comment-EPA-HQ-OAR-2023-0534-0002"]
+    assert captured["embedded"] == ["EPA comment\n\nThis proposal improves public health."]
+    assert captured["metadatas"][0]["collection"] == "regulatory_test_docs"
+
+
+def test_index_mirrulations_records_empty_returns_zero():
+    assert index_mirrulations_records([]) == 0
+
+
+def test_ingest_mirrulations_writes_requested_collection_to_jsonl(tmp_path, monkeypatch):
+    text_dir = _make_text_tree(tmp_path, agency="EPA", docket_id="EPA-HQ-OAR-2023-0534")
+    output_path = tmp_path / "mirrulations.jsonl"
+
+    monkeypatch.setattr(
+        "alcove.govdata.mirrulations.index_mirrulations_records",
+        lambda records, collection_name: len(list(records)),
+    )
+    indexed = ingest_mirrulations(
+        source=text_dir.parent.parent,
+        collection_name="regulatory_test_docs",
+        jsonl_out=output_path,
+    )
+
+    payload = output_path.read_text(encoding="utf-8")
+    assert indexed == 5
+    assert "regulatory_test_docs" in payload
+    assert "EPA-HQ-OAR-2023-0534" in payload
+
+
+def _make_text_tree(root, *, agency: str, docket_id: str):
+    text_dir = root / agency / docket_id / f"text-{docket_id}"
+    (text_dir / "docket").mkdir(parents=True)
+    (text_dir / "documents").mkdir(parents=True)
+    (text_dir / "comments").mkdir(parents=True)
+    (text_dir / "documents_extracted_text" / "pikepdf").mkdir(parents=True)
+    (text_dir / "comments_extracted_text" / "pikepdf").mkdir(parents=True)
+
+    _write_json(
+        text_dir / "docket" / f"{docket_id}.json",
+        {
+            "data": {
+                "id": docket_id,
+                "attributes": {
+                    "title": "Power Plant Emissions Rule",
+                    "summary": "Proposal to reduce sulfur dioxide and particulate emissions.",
+                },
+            }
+        },
+    )
+    _write_json(
+        text_dir / "documents" / f"{docket_id}-0001.json",
+        {
+            "data": {
+                "id": f"{docket_id}-0001",
+                "attributes": {
+                    "title": "Draft Rule Text",
+                    "category": "Rule",
+                    "postedDate": "2023-10-01",
+                },
+            }
+        },
+    )
+    (text_dir / "documents" / f"{docket_id}-0001_content.htm").write_text(
+        "<html><body><p>The proposed rule lowers emissions limits for coal plants.</p></body></html>",
+        encoding="utf-8",
+    )
+    _write_json(
+        text_dir / "comments" / f"{docket_id}-0002.json",
+        {
+            "data": {
+                "id": f"{docket_id}-0002",
+                "attributes": {
+                    "organization": "Clean Air Alliance",
+                    "comment": "<p>This proposal improves public health.</p>",
+                    "modifyDate": "2023-10-12T14:17:51Z",
+                },
+            }
+        },
+    )
+    (text_dir / "documents_extracted_text" / "pikepdf" / f"{docket_id}-0001_content_extracted.txt").write_text(
+        "Attachment appendix with emissions tables.",
+        encoding="utf-8",
+    )
+    (text_dir / "comments_extracted_text" / "pikepdf" / f"{docket_id}-0002_attachment_1_extracted.txt").write_text(
+        "Attached epidemiology study supporting tighter particulate controls.",
+        encoding="utf-8",
+    )
+    return text_dir
+
+
+def _write_json(path, payload):
+    path.write_text(json.dumps(payload), encoding="utf-8")

--- a/tests/test_govdata_mirrulations.py
+++ b/tests/test_govdata_mirrulations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -112,6 +113,50 @@ def test_index_mirrulations_records_tags_requested_collection(monkeypatch):
 
 def test_index_mirrulations_records_empty_returns_zero():
     assert index_mirrulations_records([]) == 0
+
+
+def test_mirrulations_loader_handles_alternate_payload_shapes(tmp_path):
+    text_dir = tmp_path / "EPA" / "EPA-HQ-OAR-2023-0534" / "text-EPA-HQ-OAR-2023-0534"
+    (text_dir / "docket").mkdir(parents=True)
+    (text_dir / "documents").mkdir()
+    (text_dir / "comments").mkdir()
+    (text_dir / "documents_extracted_text" / "pikepdf").mkdir(parents=True)
+
+    _write_json(
+        text_dir / "docket" / "EPA-HQ-OAR-2023-0534.json",
+        {"attributes": {"description": "Fallback docket description.", "modifyDate": "2024-02-03"}},
+    )
+    _write_json(
+        text_dir / "documents" / "doc.json",
+        {"id": "EPA-HQ-OAR-2023-0534-0003", "attributes": {"abstract": "Fallback abstract body."}},
+    )
+    _write_json(
+        text_dir / "comments" / "comment.json",
+        {"attributes": {"commentText": "Fallback public comment body.", "title": "Fallback Comment"}},
+    )
+    (text_dir / "documents_extracted_text" / "pikepdf" / "EPA-HQ-OAR-2023-0534-0003_content.txt").write_text(
+        "Content suffix attachment text.",
+        encoding="utf-8",
+    )
+    (text_dir / "documents_extracted_text" / "pikepdf" / "empty.txt").write_text("", encoding="utf-8")
+
+    records = load_mirrulations_records(tmp_path)
+
+    assert {record["metadata"]["entry_type"] for record in records} == {"docket", "document", "comment", "attachment"}
+    assert any(record["metadata"]["posted_date"] == "2024-02-03" for record in records)
+    attachment = next(record for record in records if record["metadata"]["entry_type"] == "attachment")
+    assert attachment["metadata"]["parent_id"] == "EPA-HQ-OAR-2023-0534-0003"
+
+
+def test_mirrulations_helpers_cover_fallbacks():
+    from alcove.govdata import mirrulations
+
+    assert mirrulations._load_indexing_dependencies()[0].__name__ == "get_embedder"
+    assert mirrulations._extract_attributes({"data": []}) == {}
+    assert mirrulations._extract_entity_id({"data": {"id": ""}, "id": ""}, fallback="fallback-id") == "fallback-id"
+    assert mirrulations._agency_for_text_dir(Path("text-ORPHAN")) == "UNKNOWN"
+    assert mirrulations._parent_id_for_attachment("plain_content") == "plain"
+    assert mirrulations._compose_record_text("Same", "Same") == "Same"
 
 
 def test_ingest_mirrulations_writes_requested_collection_to_jsonl(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add a local Mirrulations `text-*` corpus loader for public Regulations.gov mirror data
- expose `alcove mirrulations-demo` for indexing local docket/document/comment subsets
- document the corpus shape and update CHANGELOG/ROADMAP for the public loader

## Verification
- `python3 -m pytest tests/test_govdata_mirrulations.py tests/test_cli.py`
- `python3 -m pytest`
- privacy scan of changed feature files found no private deployment, host, token, or PII strings; the only external URL added is public `https://www.regulations.gov`

Draft until reviewed by John.
