### PR TITLE
Add read-only browse mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to alcove-search.
 
+## [Unreleased]
+
+- Add a read-only browse mode for recent indexed documents, collections, file types, authors, and years.
+
 ## [0.3.0] - 2026-03-07
 
 - Add theme toggle, fix WCAG AA contrast, update accessibility docs

--- a/alcove/index/backend.py
+++ b/alcove/index/backend.py
@@ -153,6 +153,13 @@ class MultiChromaBackend:
             result.append({"name": col.name, "doc_count": col.count()})
         return result
 
+    def iter_metadata_records(self) -> List[Dict[str, object]]:
+        """Return stored metadata records for read-only corpus browsing."""
+        records: List[Dict[str, object]] = []
+        for col in self._get_all_collections():
+            records.extend(_collection_metadata_records(col, collection_name=col.name))
+        return records
+
 
 class MultiRootBackend:
     """Vector backend that fans out across multiple ChromaDB directories.
@@ -263,6 +270,13 @@ class MultiRootBackend:
     def list_collections(self) -> List[Dict[str, object]]:
         return [{"name": name, "doc_count": col.count()} for name, _, col in self._cols]
 
+    def iter_metadata_records(self) -> List[Dict[str, object]]:
+        """Return stored metadata records for read-only corpus browsing."""
+        records: List[Dict[str, object]] = []
+        for name, _client, col in self._cols:
+            records.extend(_collection_metadata_records(col, collection_name=name))
+        return records
+
 
 class ChromaBackend:
     """Vector backend backed by local ChromaDB."""
@@ -302,6 +316,10 @@ class ChromaBackend:
             name = (meta or {}).get("collection", "default")
             counts[name] = counts.get(name, 0) + 1
         return [{"name": n, "doc_count": c} for n, c in sorted(counts.items())]
+
+    def iter_metadata_records(self) -> List[Dict[str, object]]:
+        """Return stored metadata records for read-only corpus browsing."""
+        return _collection_metadata_records(self._collection)
 
 
 class ZvecBackend:
@@ -393,6 +411,42 @@ class ZvecBackend:
             name = doc.field("collection") or "default"
             counts[name] = counts.get(name, 0) + 1
         return [{"name": n, "doc_count": c} for n, c in sorted(counts.items())]
+
+    def iter_metadata_records(self) -> List[Dict[str, object]]:
+        """Return stored metadata records for read-only corpus browsing."""
+        results = self._collection.query(
+            vectors=None,
+            topk=self.count() or 1,
+            output_fields=["source", "collection"],
+        )
+        records: List[Dict[str, object]] = []
+        for doc in results:
+            records.append({
+                "source": doc.field("source"),
+                "collection": doc.field("collection") or "default",
+            })
+        return records
+
+
+def _collection_metadata_records(
+    collection,
+    *,
+    collection_name: str | None = None,
+) -> List[Dict[str, object]]:
+    try:
+        raw = collection.get(include=["metadatas"])
+    except Exception:
+        return []
+
+    records: List[Dict[str, object]] = []
+    for meta in raw.get("metadatas") or []:
+        if not isinstance(meta, dict):
+            continue
+        record = dict(meta)
+        if collection_name:
+            record.setdefault("collection", collection_name)
+        records.append(record)
+    return records
 
 
 _BUILTIN_BACKENDS = {

--- a/alcove/query/api.py
+++ b/alcove/query/api.py
@@ -348,7 +348,7 @@ def _collection_label(meta: dict[str, Any], source: str) -> str:
         if len(rel.parts) > 1:
             return rel.parts[0]
     except (OSError, ValueError):
-        pass
+        return "default"
 
     return "default"
 

--- a/alcove/query/api.py
+++ b/alcove/query/api.py
@@ -4,10 +4,8 @@ import html
 import json
 import os
 import re
-from collections import Counter
-from datetime import datetime
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from fastapi import FastAPI, Query, Request, UploadFile, File
 from fastapi.responses import HTMLResponse, JSONResponse
@@ -17,6 +15,7 @@ from starlette.templating import Jinja2Templates
 import uvicorn
 
 from alcove.web import TEMPLATES_DIR, STATIC_DIR
+from .browse import browse_corpus_stats
 from .retriever import query_hybrid, query_keyword, query_text
 
 app = FastAPI(title="Alcove")
@@ -262,184 +261,10 @@ def list_collections():
         return []
 
 
-def _backend_metadata_records() -> list[dict[str, Any]]:
-    """Return indexed metadata records from supported local backends."""
-    from alcove.index.backend import get_backend
-    from alcove.index.embedder import get_embedder
-
-    try:
-        backend = get_backend(get_embedder())
-    except Exception:
-        return []
-
-    records: list[dict[str, Any]] = []
-
-    collection = getattr(backend, "_collection", None)
-    if collection is not None and hasattr(collection, "get"):
-        try:
-            raw = collection.get(include=["metadatas"])
-        except Exception:
-            raw = {}
-        records.extend(meta for meta in raw.get("metadatas") or [] if isinstance(meta, dict))
-        return records
-
-    get_all = getattr(backend, "_get_all_collections", None)
-    if callable(get_all):
-        for coll in get_all():
-            try:
-                raw = coll.get(include=["metadatas"])
-            except Exception:
-                continue
-            for meta in raw.get("metadatas") or []:
-                if isinstance(meta, dict):
-                    enriched = dict(meta)
-                    enriched.setdefault("collection", getattr(coll, "name", "default"))
-                    records.append(enriched)
-        return records
-
-    for name, _client, coll in getattr(backend, "_cols", []):
-        try:
-            raw = coll.get(include=["metadatas"])
-        except Exception:
-            continue
-        for meta in raw.get("metadatas") or []:
-            if isinstance(meta, dict):
-                enriched = dict(meta)
-                enriched.setdefault("collection", name)
-                records.append(enriched)
-
-    return records
-
-
-def _source_key(meta: dict[str, Any]) -> str:
-    source = str(meta.get("source") or meta.get("path") or meta.get("filename") or "").strip()
-    if source:
-        return source
-    title = str(meta.get("title") or "").strip()
-    return title or "(unknown)"
-
-
-def _source_label(source: str) -> str:
-    """Return a display label without exposing absolute local paths."""
-    if not source or source == "(unknown)":
-        return "Unknown source"
-
-    source_path = Path(source)
-    raw_dir = Path(os.getenv("RAW_DIR", "data/raw")).expanduser()
-    try:
-        return source_path.expanduser().resolve().relative_to(raw_dir.resolve()).as_posix()
-    except (OSError, ValueError):
-        pass
-
-    parts = [p for p in re.split(r"[\\/]+", source) if p]
-    if len(parts) >= 2 and parts[-2] not in {"raw", "data"}:
-        return f"{parts[-2]}/{parts[-1]}"
-    return parts[-1] if parts else source
-
-
-def _collection_label(meta: dict[str, Any], source: str) -> str:
-    collection = str(meta.get("collection") or "").strip()
-    if collection:
-        return collection
-
-    raw_dir = Path(os.getenv("RAW_DIR", "data/raw")).expanduser()
-    try:
-        rel = Path(source).expanduser().resolve().relative_to(raw_dir.resolve())
-        if len(rel.parts) > 1:
-            return rel.parts[0]
-    except (OSError, ValueError):
-        return "default"
-
-    return "default"
-
-
-def _document_sort_time(source: str, metas: list[dict[str, Any]]) -> float:
-    for key in ("uploaded_at", "indexed_at", "modified_at", "created_at"):
-        values = [str(meta.get(key) or "").strip() for meta in metas]
-        for value in values:
-            if not value:
-                continue
-            try:
-                return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
-            except ValueError:
-                continue
-
-    try:
-        return Path(source).expanduser().stat().st_mtime
-    except OSError:
-        return 0.0
-
-
-def _browse_corpus_stats() -> dict[str, list[dict[str, Any]]]:
-    """Aggregate read-only browse stats from local index metadata."""
-    records = _backend_metadata_records()
-    if not records:
-        return {"collections": [], "filetypes": [], "authors": [], "years": [], "recent": []}
-
-    grouped: dict[str, list[dict[str, Any]]] = {}
-    for meta in records:
-        grouped.setdefault(_source_key(meta), []).append(meta)
-
-    collections: Counter[str] = Counter()
-    filetypes: Counter[str] = Counter()
-    authors: Counter[str] = Counter()
-    years: Counter[str] = Counter()
-    recent: list[dict[str, Any]] = []
-
-    for source, metas in grouped.items():
-        first = metas[0]
-        label = _source_label(source)
-        collection = _collection_label(first, source)
-        collections[collection] += 1
-
-        ext = Path(label).suffix.lower().lstrip(".")
-        if ext:
-            filetypes[ext.upper()] += 1
-
-        authors_raw = str(first.get("authors") or first.get("author") or "").strip()
-        for author in re.split(r"[;|]+", authors_raw):
-            author = author.strip()
-            if author:
-                authors[author] += 1
-
-        year = str(first.get("year") or "").strip()
-        if re.fullmatch(r"\d{4}", year):
-            years[year] += 1
-
-        recent.append(
-            {
-                "label": label,
-                "collection": collection,
-                "chunk_count": len(metas),
-                "sort_time": _document_sort_time(source, metas),
-            }
-        )
-
-    return {
-        "collections": [
-            {"name": name, "doc_count": count}
-            for name, count in sorted(collections.items(), key=lambda item: (-item[1], item[0].lower()))
-        ],
-        "filetypes": [
-            {"ext": ext, "doc_count": count}
-            for ext, count in sorted(filetypes.items(), key=lambda item: (-item[1], item[0]))
-        ],
-        "authors": [
-            {"name": name, "doc_count": count}
-            for name, count in sorted(authors.items(), key=lambda item: (-item[1], item[0].lower()))[:50]
-        ],
-        "years": [
-            {"year": year, "doc_count": count}
-            for year, count in sorted(years.items(), key=lambda item: item[0], reverse=True)
-        ],
-        "recent": sorted(recent, key=lambda item: (-item["sort_time"], item["label"].lower()))[:12],
-    }
-
-
 @app.get("/browse", response_class=HTMLResponse)
 def browse(request: Request):
     """Render a read-only corpus browsing page."""
-    stats = _browse_corpus_stats()
+    stats = browse_corpus_stats()
     total_docs = sum(item["doc_count"] for item in stats["collections"])
     return templates.TemplateResponse(
         request,

--- a/alcove/query/api.py
+++ b/alcove/query/api.py
@@ -4,8 +4,10 @@ import html
 import json
 import os
 import re
+from collections import Counter
+from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from fastapi import FastAPI, Query, Request, UploadFile, File
 from fastapi.responses import HTMLResponse, JSONResponse
@@ -258,6 +260,192 @@ def list_collections():
         return backend.list_collections()
     except Exception:
         return []
+
+
+def _backend_metadata_records() -> list[dict[str, Any]]:
+    """Return indexed metadata records from supported local backends."""
+    from alcove.index.backend import get_backend
+    from alcove.index.embedder import get_embedder
+
+    try:
+        backend = get_backend(get_embedder())
+    except Exception:
+        return []
+
+    records: list[dict[str, Any]] = []
+
+    collection = getattr(backend, "_collection", None)
+    if collection is not None and hasattr(collection, "get"):
+        try:
+            raw = collection.get(include=["metadatas"])
+        except Exception:
+            raw = {}
+        records.extend(meta for meta in raw.get("metadatas") or [] if isinstance(meta, dict))
+        return records
+
+    get_all = getattr(backend, "_get_all_collections", None)
+    if callable(get_all):
+        for coll in get_all():
+            try:
+                raw = coll.get(include=["metadatas"])
+            except Exception:
+                continue
+            for meta in raw.get("metadatas") or []:
+                if isinstance(meta, dict):
+                    enriched = dict(meta)
+                    enriched.setdefault("collection", getattr(coll, "name", "default"))
+                    records.append(enriched)
+        return records
+
+    for name, _client, coll in getattr(backend, "_cols", []):
+        try:
+            raw = coll.get(include=["metadatas"])
+        except Exception:
+            continue
+        for meta in raw.get("metadatas") or []:
+            if isinstance(meta, dict):
+                enriched = dict(meta)
+                enriched.setdefault("collection", name)
+                records.append(enriched)
+
+    return records
+
+
+def _source_key(meta: dict[str, Any]) -> str:
+    source = str(meta.get("source") or meta.get("path") or meta.get("filename") or "").strip()
+    if source:
+        return source
+    title = str(meta.get("title") or "").strip()
+    return title or "(unknown)"
+
+
+def _source_label(source: str) -> str:
+    """Return a display label without exposing absolute local paths."""
+    if not source or source == "(unknown)":
+        return "Unknown source"
+
+    source_path = Path(source)
+    raw_dir = Path(os.getenv("RAW_DIR", "data/raw")).expanduser()
+    try:
+        return source_path.expanduser().resolve().relative_to(raw_dir.resolve()).as_posix()
+    except (OSError, ValueError):
+        pass
+
+    parts = [p for p in re.split(r"[\\/]+", source) if p]
+    if len(parts) >= 2 and parts[-2] not in {"raw", "data"}:
+        return f"{parts[-2]}/{parts[-1]}"
+    return parts[-1] if parts else source
+
+
+def _collection_label(meta: dict[str, Any], source: str) -> str:
+    collection = str(meta.get("collection") or "").strip()
+    if collection:
+        return collection
+
+    raw_dir = Path(os.getenv("RAW_DIR", "data/raw")).expanduser()
+    try:
+        rel = Path(source).expanduser().resolve().relative_to(raw_dir.resolve())
+        if len(rel.parts) > 1:
+            return rel.parts[0]
+    except (OSError, ValueError):
+        pass
+
+    return "default"
+
+
+def _document_sort_time(source: str, metas: list[dict[str, Any]]) -> float:
+    for key in ("uploaded_at", "indexed_at", "modified_at", "created_at"):
+        values = [str(meta.get(key) or "").strip() for meta in metas]
+        for value in values:
+            if not value:
+                continue
+            try:
+                return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+            except ValueError:
+                continue
+
+    try:
+        return Path(source).expanduser().stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def _browse_corpus_stats() -> dict[str, list[dict[str, Any]]]:
+    """Aggregate read-only browse stats from local index metadata."""
+    records = _backend_metadata_records()
+    if not records:
+        return {"collections": [], "filetypes": [], "authors": [], "years": [], "recent": []}
+
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for meta in records:
+        grouped.setdefault(_source_key(meta), []).append(meta)
+
+    collections: Counter[str] = Counter()
+    filetypes: Counter[str] = Counter()
+    authors: Counter[str] = Counter()
+    years: Counter[str] = Counter()
+    recent: list[dict[str, Any]] = []
+
+    for source, metas in grouped.items():
+        first = metas[0]
+        label = _source_label(source)
+        collection = _collection_label(first, source)
+        collections[collection] += 1
+
+        ext = Path(label).suffix.lower().lstrip(".")
+        if ext:
+            filetypes[ext.upper()] += 1
+
+        authors_raw = str(first.get("authors") or first.get("author") or "").strip()
+        for author in re.split(r"[;|]+", authors_raw):
+            author = author.strip()
+            if author:
+                authors[author] += 1
+
+        year = str(first.get("year") or "").strip()
+        if re.fullmatch(r"\d{4}", year):
+            years[year] += 1
+
+        recent.append(
+            {
+                "label": label,
+                "collection": collection,
+                "chunk_count": len(metas),
+                "sort_time": _document_sort_time(source, metas),
+            }
+        )
+
+    return {
+        "collections": [
+            {"name": name, "doc_count": count}
+            for name, count in sorted(collections.items(), key=lambda item: (-item[1], item[0].lower()))
+        ],
+        "filetypes": [
+            {"ext": ext, "doc_count": count}
+            for ext, count in sorted(filetypes.items(), key=lambda item: (-item[1], item[0]))
+        ],
+        "authors": [
+            {"name": name, "doc_count": count}
+            for name, count in sorted(authors.items(), key=lambda item: (-item[1], item[0].lower()))[:50]
+        ],
+        "years": [
+            {"year": year, "doc_count": count}
+            for year, count in sorted(years.items(), key=lambda item: item[0], reverse=True)
+        ],
+        "recent": sorted(recent, key=lambda item: (-item["sort_time"], item["label"].lower()))[:12],
+    }
+
+
+@app.get("/browse", response_class=HTMLResponse)
+def browse(request: Request):
+    """Render a read-only corpus browsing page."""
+    stats = _browse_corpus_stats()
+    total_docs = sum(item["doc_count"] for item in stats["collections"])
+    return templates.TemplateResponse(
+        request,
+        "browse.html",
+        _tpl({"stats": stats, "total_docs": total_docs}),
+    )
 
 
 def _dispatch_query(

--- a/alcove/query/browse.py
+++ b/alcove/query/browse.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import os
+import re
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+EMPTY_BROWSE_STATS = {
+    "collections": [],
+    "filetypes": [],
+    "authors": [],
+    "years": [],
+    "recent": [],
+}
+
+
+def backend_metadata_records() -> list[dict[str, Any]]:
+    """Return indexed metadata records through the backend browse interface."""
+    from alcove.index.backend import get_backend
+    from alcove.index.embedder import get_embedder
+
+    try:
+        backend = get_backend(get_embedder())
+        records = backend.iter_metadata_records()
+    except Exception:
+        return []
+    return [dict(meta) for meta in records if isinstance(meta, dict)]
+
+
+def browse_corpus_stats(records: list[dict[str, Any]] | None = None) -> dict[str, list[dict[str, Any]]]:
+    """Aggregate read-only browse stats from local index metadata."""
+    records = backend_metadata_records() if records is None else records
+    if not records:
+        return dict(EMPTY_BROWSE_STATS)
+
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for meta in records:
+        grouped.setdefault(source_key(meta), []).append(meta)
+
+    collections: Counter[str] = Counter()
+    filetypes: Counter[str] = Counter()
+    authors: Counter[str] = Counter()
+    years: Counter[str] = Counter()
+    recent: list[dict[str, Any]] = []
+
+    for source, metas in grouped.items():
+        first = metas[0]
+        label = source_label(source)
+        collection = collection_label(first, source)
+        collections[collection] += 1
+
+        ext = Path(label).suffix.lower().lstrip(".")
+        if ext:
+            filetypes[ext.upper()] += 1
+
+        for author in metadata_authors(first):
+            authors[author] += 1
+
+        year = str(first.get("year") or "").strip()
+        if re.fullmatch(r"\d{4}", year):
+            years[year] += 1
+
+        recent.append({
+            "label": label,
+            "collection": collection,
+            "chunk_count": len(metas),
+            "sort_time": document_sort_time(source, metas),
+        })
+
+    return {
+        "collections": counted_items(collections, "name"),
+        "filetypes": counted_items(filetypes, "ext"),
+        "authors": counted_items(authors, "name")[:50],
+        "years": [
+            {"year": year, "doc_count": count}
+            for year, count in sorted(years.items(), key=lambda item: item[0], reverse=True)
+        ],
+        "recent": sorted(recent, key=lambda item: (-item["sort_time"], item["label"].lower()))[:12],
+    }
+
+
+def counted_items(counter: Counter[str], key: str) -> list[dict[str, Any]]:
+    return [
+        {key: name, "doc_count": count}
+        for name, count in sorted(counter.items(), key=lambda item: (-item[1], item[0].lower()))
+    ]
+
+
+def source_key(meta: dict[str, Any]) -> str:
+    source = str(meta.get("source") or meta.get("path") or meta.get("filename") or "").strip()
+    if source:
+        return source
+    title = str(meta.get("title") or "").strip()
+    return title or "(unknown)"
+
+
+def source_label(source: str) -> str:
+    """Return a display label without exposing absolute local paths."""
+    if not source or source == "(unknown)":
+        return "Unknown source"
+
+    source_path = Path(source)
+    raw_dir = Path(os.getenv("RAW_DIR", "data/raw")).expanduser()
+    try:
+        return source_path.expanduser().resolve().relative_to(raw_dir.resolve()).as_posix()
+    except (OSError, ValueError):
+        pass
+
+    parts = [part for part in re.split(r"[\\/]+", source) if part]
+    if len(parts) >= 2 and parts[-2] not in {"raw", "data"}:
+        return f"{parts[-2]}/{parts[-1]}"
+    return parts[-1] if parts else source
+
+
+def collection_label(meta: dict[str, Any], source: str) -> str:
+    collection = str(meta.get("collection") or "").strip()
+    if collection:
+        return collection
+
+    raw_dir = Path(os.getenv("RAW_DIR", "data/raw")).expanduser()
+    try:
+        rel = Path(source).expanduser().resolve().relative_to(raw_dir.resolve())
+    except (OSError, ValueError):
+        return "default"
+    if len(rel.parts) > 1:
+        return rel.parts[0]
+    return "default"
+
+
+def metadata_authors(meta: dict[str, Any]) -> list[str]:
+    authors_raw = str(meta.get("authors") or meta.get("author") or "").strip()
+    return [author.strip() for author in re.split(r"[;|]+", authors_raw) if author.strip()]
+
+
+def document_sort_time(source: str, metas: list[dict[str, Any]]) -> float:
+    for key in ("uploaded_at", "indexed_at", "modified_at", "created_at"):
+        values = [str(meta.get(key) or "").strip() for meta in metas]
+        for value in values:
+            if not value:
+                continue
+            try:
+                return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+            except ValueError:
+                continue
+
+    try:
+        return Path(source).expanduser().stat().st_mtime
+    except OSError:
+        return 0.0

--- a/alcove/web/static/style.css
+++ b/alcove/web/static/style.css
@@ -260,6 +260,31 @@ button:focus-visible {
   color: var(--gold-dim);
 }
 
+.site-nav {
+  display: flex;
+  gap: 0.4rem;
+  margin-top: 0.35rem;
+}
+
+.site-nav a {
+  min-height: 36px;
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--gold);
+  font-size: 0.875rem;
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+  text-decoration: none;
+}
+
+.site-nav a:hover {
+  background: var(--gold-faint);
+  border-color: var(--border-hover);
+  text-decoration: none;
+}
+
 /* ---- Main content ---- */
 
 .site-main {
@@ -653,6 +678,149 @@ button:focus-visible {
   text-align: center;
 }
 
+/* ---- Browse Mode ---- */
+
+.browse-hero {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 0.8fr);
+  gap: 1rem;
+  align-items: end;
+  margin-bottom: 1rem;
+}
+
+.browse-hero h2 {
+  font-size: 1.6rem;
+  line-height: 1.15;
+  margin-bottom: 0.4rem;
+}
+
+.browse-hero p {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.browse-search {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.browse-search input[type="text"] {
+  min-width: 0;
+  width: 100%;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  font-size: 0.9375rem;
+  padding: 0.875rem 1rem;
+}
+
+.browse-search input[type="text"]:focus {
+  border-color: var(--gold);
+  box-shadow: 0 0 0 3px var(--gold-glow);
+  outline: none;
+}
+
+.browse-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.875rem;
+}
+
+.browse-panel {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1rem;
+}
+
+.browse-panel-wide {
+  grid-column: 1 / -1;
+}
+
+.browse-panel-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.browse-panel h3 {
+  font-size: 1rem;
+  line-height: 1.25;
+}
+
+.browse-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.browse-list-item {
+  min-width: 0;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 0.7rem 0.8rem;
+}
+
+.browse-list-title {
+  display: block;
+  color: var(--text);
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.browse-list-meta {
+  display: block;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  margin-top: 0.1rem;
+}
+
+.browse-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.browse-chip {
+  min-height: 38px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text);
+  padding: 0.35rem 0.65rem;
+  text-decoration: none;
+}
+
+.browse-chip span:last-child {
+  color: var(--gold);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.browse-chip:hover {
+  background: var(--gold-faint);
+  border-color: var(--border-hover);
+  text-decoration: none;
+}
+
+.browse-chip-static:hover {
+  background: transparent;
+  border-color: var(--border);
+}
+
 /* ---- Results header ---- */
 
 .results-header {
@@ -929,6 +1097,15 @@ a:hover {
   }
 
   .search-form {
+    flex-direction: column;
+  }
+
+  .browse-hero,
+  .browse-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .browse-search {
     flex-direction: column;
   }
 

--- a/alcove/web/templates/base.html
+++ b/alcove/web/templates/base.html
@@ -30,6 +30,10 @@
           <h1 class="site-title">Alcove</h1>
         </div>
         <p class="site-tagline">Local-first retrieval</p>
+        <nav class="site-nav" aria-label="Primary">
+          <a href="{{ base_url }}/">Search</a>
+          <a href="{{ base_url }}/browse">Browse</a>
+        </nav>
       </div>
     </header>
 

--- a/alcove/web/templates/browse.html
+++ b/alcove/web/templates/browse.html
@@ -1,0 +1,109 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <section class="browse-hero" aria-labelledby="browse-heading">
+    <div>
+      <p class="section-kicker">Browse mode</p>
+      <h2 id="browse-heading">Explore the local index</h2>
+      <p>
+        {% if total_docs == 1 %}
+        1 source document is represented in the index.
+        {% else %}
+        {{ total_docs }} source documents are represented in the index.
+        {% endif %}
+      </p>
+    </div>
+    <form class="browse-search" method="GET" action="{{ base_url }}/search" role="search">
+      <label class="sr-only" for="browse-search-input">Search your documents</label>
+      <input id="browse-search-input" type="text" name="q" placeholder="Search from browse mode">
+      <button class="search-btn" type="submit">Search</button>
+    </form>
+  </section>
+
+  {% if total_docs == 0 %}
+  <div class="welcome-banner" role="status">
+    <h2>No documents indexed yet</h2>
+    <p>Upload documents or run <code>alcove seed-demo</code>, then return here to browse the corpus.</p>
+  </div>
+  {% else %}
+  <div class="browse-grid">
+    <section class="browse-panel" aria-labelledby="recent-documents-heading">
+      <div class="browse-panel-heading">
+        <h3 id="recent-documents-heading">Recent Documents</h3>
+      </div>
+      <div class="browse-list">
+        {% for doc in stats.recent %}
+        <div class="browse-list-item">
+          <span class="browse-list-title" title="{{ doc.label | e }}">{{ doc.label | e }}</span>
+          <span class="browse-list-meta">{{ doc.collection | e }} &middot; {{ doc.chunk_count }} chunk{% if doc.chunk_count != 1 %}s{% endif %}</span>
+        </div>
+        {% endfor %}
+      </div>
+    </section>
+
+    <section class="browse-panel" aria-labelledby="collections-heading">
+      <div class="browse-panel-heading">
+        <h3 id="collections-heading">Collections</h3>
+      </div>
+      <div class="browse-chips">
+        {% for collection in stats.collections %}
+        <a class="browse-chip" href="{{ base_url }}/search?collections={{ collection.name | urlencode }}">
+          <span>{{ collection.name | e }}</span>
+          <span>{{ collection.doc_count }}</span>
+        </a>
+        {% endfor %}
+      </div>
+    </section>
+
+    {% if stats.filetypes %}
+    <section class="browse-panel" aria-labelledby="filetypes-heading">
+      <div class="browse-panel-heading">
+        <h3 id="filetypes-heading">File Types</h3>
+      </div>
+      <div class="browse-chips">
+        {% for filetype in stats.filetypes %}
+        <span class="browse-chip browse-chip-static">
+          <span>{{ filetype.ext | e }}</span>
+          <span>{{ filetype.doc_count }}</span>
+        </span>
+        {% endfor %}
+      </div>
+    </section>
+    {% endif %}
+
+    {% if stats.years %}
+    <section class="browse-panel" aria-labelledby="years-heading">
+      <div class="browse-panel-heading">
+        <h3 id="years-heading">Years</h3>
+      </div>
+      <div class="browse-chips">
+        {% for year in stats.years %}
+        <a class="browse-chip" href="{{ base_url }}/search?q={{ year.year | urlencode }}">
+          <span>{{ year.year | e }}</span>
+          <span>{{ year.doc_count }}</span>
+        </a>
+        {% endfor %}
+      </div>
+    </section>
+    {% endif %}
+
+    {% if stats.authors %}
+    <section class="browse-panel browse-panel-wide" aria-labelledby="authors-heading">
+      <div class="browse-panel-heading">
+        <h3 id="authors-heading">Authors</h3>
+      </div>
+      <div class="browse-chips">
+        {% for author in stats.authors %}
+        <a class="browse-chip" href="{{ base_url }}/search?q={{ author.name | urlencode }}">
+          <span>{{ author.name | e }}</span>
+          <span>{{ author.doc_count }}</span>
+        </a>
+        {% endfor %}
+      </div>
+    </section>
+    {% endif %}
+  </div>
+  {% endif %}
+
+  <a class="back-link" href="{{ base_url }}/">&#8592; Back to search</a>
+{% endblock %}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -52,6 +52,19 @@ Set the embedder with the `EMBEDDER` environment variable. See [OPERATIONS.md](O
 
 Set the backend with the `VECTOR_BACKEND` environment variable. See [OPERATIONS.md](OPERATIONS.md#environment-variables) for how to configure it.
 
+## Browse mode
+
+Browse mode is a core, read-only view over indexed metadata. It does not inspect
+raw corpus files directly and does not mutate the index. Backends expose stored
+metadata through `iter_metadata_records()`, and `alcove/query/browse.py`
+aggregates that metadata into source-document facets such as collection, file
+type, author, year, and recent documents.
+
+Backend plugins should implement `iter_metadata_records()` when they want the
+core web UI's `/browse` page to show corpus facets. If a backend cannot enumerate
+metadata records, browse mode falls back to an empty state while search remains
+available.
+
 ## Plugin system
 
 Custom extractors, embedders, and vector backends plug in via [Python entry points](https://packaging.python.org/en/latest/specifications/entry-points/). Three extension groups:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ This is the foundation. Everything below builds on it.
 
 **Semantic search as default.** The hash embedder exists for zero-download offline bootstrapping and for operators who do not want ML in the pipeline. Once the onboarding experience is smooth enough, sentence-transformers (or a lighter alternative) becomes the default install. The hash embedder stays available: not a stepping stone, but a permanent option for people who want deterministic, inspectable results.
 
-**Browse mode.** Alcove should be navigable, not just searchable. Directory-aware corpus browsing in the web UI: see what you have, not just what matches a query. Search and browse are complementary interfaces to the same index.
+**Browse mode.** Alcove is now navigable, not just searchable: the web UI includes a read-only browse page for recent indexed documents, collections, file types, authors, and years. Next steps are deeper directory-aware browsing and document-level drill-down while keeping the surface retrieval-only.
 
 **MCP endpoint.** This is the "share it with the universe" part. An MCP-compatible retrieval surface that lets AI tools, public-facing websites, or any other tool query your index. Your corpus stays local. Your index stays yours. The answers are available to whoever you choose to expose them to. Because Alcove is retrieval, not generation, those answers are what your documents actually say: no hallucinations, no editorializing, no slop. Alcove already runs a local API; exposing it as an MCP tool server is a natural extension. [MCP changes the security surface](SECURITY.md#security-model); review it before exposing the endpoint. Context7 compatibility is a goal.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -218,6 +218,114 @@ def test_browse_page_renders_facets(monkeypatch):
     assert "Ada Lovelace" in r.text
 
 
+def test_backend_metadata_records_handles_collection_backend(monkeypatch):
+    from alcove.query import api as api_mod
+
+    class DummyCollection:
+        def get(self, include):
+            assert include == ["metadatas"]
+            return {"metadatas": [{"source": "data/raw/a.md"}, None, {"source": "data/raw/b.md"}]}
+
+    class DummyBackend:
+        _collection = DummyCollection()
+
+    monkeypatch.setattr("alcove.index.embedder.get_embedder", lambda: object())
+    monkeypatch.setattr("alcove.index.backend.get_backend", lambda embedder: DummyBackend())
+
+    assert api_mod._backend_metadata_records() == [{"source": "data/raw/a.md"}, {"source": "data/raw/b.md"}]
+
+
+def test_backend_metadata_records_handles_collection_errors(monkeypatch):
+    from alcove.query import api as api_mod
+
+    class BrokenCollection:
+        def get(self, include):
+            raise RuntimeError("unavailable")
+
+    class DummyBackend:
+        _collection = BrokenCollection()
+
+    monkeypatch.setattr("alcove.index.embedder.get_embedder", lambda: object())
+    monkeypatch.setattr("alcove.index.backend.get_backend", lambda embedder: DummyBackend())
+
+    assert api_mod._backend_metadata_records() == []
+
+
+def test_backend_metadata_records_handles_backend_factory_error(monkeypatch):
+    from alcove.query import api as api_mod
+
+    monkeypatch.setattr("alcove.index.embedder.get_embedder", lambda: object())
+    monkeypatch.setattr("alcove.index.backend.get_backend", lambda embedder: (_ for _ in ()).throw(RuntimeError("no db")))
+
+    assert api_mod._backend_metadata_records() == []
+
+
+def test_backend_metadata_records_handles_multi_collection_backend(monkeypatch):
+    from alcove.query import api as api_mod
+
+    class DummyCollection:
+        name = "science"
+
+        def get(self, include):
+            return {"metadatas": [{"source": "data/raw/paper.md"}]}
+
+    class BrokenCollection:
+        name = "broken"
+
+        def get(self, include):
+            raise RuntimeError("unavailable")
+
+    class DummyBackend:
+        def _get_all_collections(self):
+            return [DummyCollection(), BrokenCollection()]
+
+    monkeypatch.setattr("alcove.index.embedder.get_embedder", lambda: object())
+    monkeypatch.setattr("alcove.index.backend.get_backend", lambda embedder: DummyBackend())
+
+    assert api_mod._backend_metadata_records() == [{"source": "data/raw/paper.md", "collection": "science"}]
+
+
+def test_backend_metadata_records_handles_zvec_collection_cache(monkeypatch):
+    from alcove.query import api as api_mod
+
+    class DummyCollection:
+        def get(self, include):
+            return {"metadatas": [{"source": "data/raw/cache.md"}]}
+
+    class BrokenCollection:
+        def get(self, include):
+            raise RuntimeError("unavailable")
+
+    class DummyBackend:
+        _cols = [("cache", object(), DummyCollection()), ("broken", object(), BrokenCollection())]
+
+    monkeypatch.setattr("alcove.index.embedder.get_embedder", lambda: object())
+    monkeypatch.setattr("alcove.index.backend.get_backend", lambda embedder: DummyBackend())
+
+    assert api_mod._backend_metadata_records() == [{"source": "data/raw/cache.md", "collection": "cache"}]
+
+
+def test_browse_helpers_handle_fallbacks(tmp_path, monkeypatch):
+    from alcove.query import api as api_mod
+
+    raw_dir = tmp_path / "raw"
+    source = raw_dir / "letters" / "note.txt"
+    source.parent.mkdir(parents=True)
+    source.write_text("hello", encoding="utf-8")
+    monkeypatch.setenv("RAW_DIR", str(raw_dir))
+
+    assert api_mod._source_key({"title": "Untitled"}) == "Untitled"
+    assert api_mod._source_key({}) == "(unknown)"
+    assert api_mod._source_label("(unknown)") == "Unknown source"
+    assert api_mod._source_label(str(source)) == "letters/note.txt"
+    assert api_mod._source_label("/external/archive/note.txt") == "archive/note.txt"
+    assert api_mod._source_label("") == "Unknown source"
+    assert api_mod._collection_label({}, str(source)) == "letters"
+    assert api_mod._collection_label({}, "/external/note.txt") == "default"
+    assert api_mod._document_sort_time("missing.txt", [{"uploaded_at": "not-a-date"}]) == 0.0
+    assert api_mod._document_sort_time(str(source), [{}]) > 0
+
+
 def test_root_backend_exception_still_renders_html():
     """GET / renders the search page even when the backend raises (doc_count falls back to 0)."""
     from unittest.mock import patch

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -146,6 +146,78 @@ def test_list_collections_backend_exception_returns_empty():
     assert r.json() == []
 
 
+def test_browse_empty_index_returns_html(monkeypatch):
+    """GET /browse renders an empty state when no backend metadata is available."""
+    from alcove.query import api as api_mod
+
+    monkeypatch.setattr(api_mod, "_backend_metadata_records", lambda: [])
+    r = client.get("/browse")
+    assert r.status_code == 200
+    assert "text/html" in r.headers["content-type"]
+    assert "No documents indexed yet" in r.text
+
+
+def test_browse_corpus_stats_groups_source_documents(monkeypatch):
+    """Browse stats count source documents, not chunks, and avoid absolute path display."""
+    from alcove.query import api as api_mod
+
+    monkeypatch.setattr(
+        api_mod,
+        "_backend_metadata_records",
+        lambda: [
+            {
+                "source": "/tmp/alcove-corpus/science/einstein.pdf",
+                "collection": "science",
+                "authors": "Einstein, A.",
+                "year": "1905",
+            },
+            {
+                "source": "/tmp/alcove-corpus/science/einstein.pdf",
+                "collection": "science",
+            },
+            {
+                "source": "data/raw/history/founding.txt",
+                "collection": "history",
+                "year": "1787",
+            },
+        ],
+    )
+
+    stats = api_mod._browse_corpus_stats()
+
+    assert {"name": "science", "doc_count": 1} in stats["collections"]
+    assert {"name": "history", "doc_count": 1} in stats["collections"]
+    assert {"ext": "PDF", "doc_count": 1} in stats["filetypes"]
+    assert {"ext": "TXT", "doc_count": 1} in stats["filetypes"]
+    assert stats["authors"] == [{"name": "Einstein, A.", "doc_count": 1}]
+    assert {"year": "1905", "doc_count": 1} in stats["years"]
+    assert all("/tmp/alcove-corpus" not in item["label"] for item in stats["recent"])
+
+
+def test_browse_page_renders_facets(monkeypatch):
+    """GET /browse renders recent documents, collections, and facet chips."""
+    from alcove.query import api as api_mod
+
+    monkeypatch.setattr(
+        api_mod,
+        "_backend_metadata_records",
+        lambda: [
+            {
+                "source": "data/raw/research/paper.md",
+                "collection": "research",
+                "authors": "Ada Lovelace",
+                "year": "1843",
+            }
+        ],
+    )
+    r = client.get("/browse")
+    assert r.status_code == 200
+    assert "Recent Documents" in r.text
+    assert "paper.md" in r.text
+    assert "research" in r.text
+    assert "Ada Lovelace" in r.text
+
+
 def test_root_backend_exception_still_renders_html():
     """GET / renders the search page even when the backend raises (doc_count falls back to 0)."""
     from unittest.mock import patch

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -150,7 +150,11 @@ def test_browse_empty_index_returns_html(monkeypatch):
     """GET /browse renders an empty state when no backend metadata is available."""
     from alcove.query import api as api_mod
 
-    monkeypatch.setattr(api_mod, "_backend_metadata_records", lambda: [])
+    monkeypatch.setattr(
+        api_mod,
+        "browse_corpus_stats",
+        lambda: {"collections": [], "filetypes": [], "authors": [], "years": [], "recent": []},
+    )
     r = client.get("/browse")
     assert r.status_code == 200
     assert "text/html" in r.headers["content-type"]
@@ -159,31 +163,25 @@ def test_browse_empty_index_returns_html(monkeypatch):
 
 def test_browse_corpus_stats_groups_source_documents(monkeypatch):
     """Browse stats count source documents, not chunks, and avoid absolute path display."""
-    from alcove.query import api as api_mod
+    from alcove.query.browse import browse_corpus_stats
 
-    monkeypatch.setattr(
-        api_mod,
-        "_backend_metadata_records",
-        lambda: [
-            {
-                "source": "/tmp/alcove-corpus/science/einstein.pdf",
-                "collection": "science",
-                "authors": "Einstein, A.",
-                "year": "1905",
-            },
-            {
-                "source": "/tmp/alcove-corpus/science/einstein.pdf",
-                "collection": "science",
-            },
-            {
-                "source": "data/raw/history/founding.txt",
-                "collection": "history",
-                "year": "1787",
-            },
-        ],
-    )
-
-    stats = api_mod._browse_corpus_stats()
+    stats = browse_corpus_stats([
+        {
+            "source": "/tmp/alcove-corpus/science/einstein.pdf",
+            "collection": "science",
+            "authors": "Einstein, A.",
+            "year": "1905",
+        },
+        {
+            "source": "/tmp/alcove-corpus/science/einstein.pdf",
+            "collection": "science",
+        },
+        {
+            "source": "data/raw/history/founding.txt",
+            "collection": "history",
+            "year": "1787",
+        },
+    ])
 
     assert {"name": "science", "doc_count": 1} in stats["collections"]
     assert {"name": "history", "doc_count": 1} in stats["collections"]
@@ -197,18 +195,19 @@ def test_browse_corpus_stats_groups_source_documents(monkeypatch):
 def test_browse_page_renders_facets(monkeypatch):
     """GET /browse renders recent documents, collections, and facet chips."""
     from alcove.query import api as api_mod
+    from alcove.query.browse import browse_corpus_stats
 
     monkeypatch.setattr(
         api_mod,
-        "_backend_metadata_records",
-        lambda: [
+        "browse_corpus_stats",
+        lambda: browse_corpus_stats([
             {
                 "source": "data/raw/research/paper.md",
                 "collection": "research",
                 "authors": "Ada Lovelace",
                 "year": "1843",
             }
-        ],
+        ]),
     )
     r = client.get("/browse")
     assert r.status_code == 200
@@ -218,95 +217,30 @@ def test_browse_page_renders_facets(monkeypatch):
     assert "Ada Lovelace" in r.text
 
 
-def test_backend_metadata_records_handles_collection_backend(monkeypatch):
-    from alcove.query import api as api_mod
-
-    class DummyCollection:
-        def get(self, include):
-            assert include == ["metadatas"]
-            return {"metadatas": [{"source": "data/raw/a.md"}, None, {"source": "data/raw/b.md"}]}
+def test_backend_metadata_records_uses_backend_public_interface(monkeypatch):
+    from alcove.query.browse import backend_metadata_records
 
     class DummyBackend:
-        _collection = DummyCollection()
+        def iter_metadata_records(self):
+            return [{"source": "data/raw/a.md"}, None, {"source": "data/raw/b.md"}]
 
     monkeypatch.setattr("alcove.index.embedder.get_embedder", object)
     monkeypatch.setattr("alcove.index.backend.get_backend", lambda embedder: DummyBackend())
 
-    assert api_mod._backend_metadata_records() == [{"source": "data/raw/a.md"}, {"source": "data/raw/b.md"}]
-
-
-def test_backend_metadata_records_handles_collection_errors(monkeypatch):
-    from alcove.query import api as api_mod
-
-    class BrokenCollection:
-        def get(self, include):
-            raise RuntimeError("unavailable")
-
-    class DummyBackend:
-        _collection = BrokenCollection()
-
-    monkeypatch.setattr("alcove.index.embedder.get_embedder", object)
-    monkeypatch.setattr("alcove.index.backend.get_backend", lambda embedder: DummyBackend())
-
-    assert api_mod._backend_metadata_records() == []
+    assert backend_metadata_records() == [{"source": "data/raw/a.md"}, {"source": "data/raw/b.md"}]
 
 
 def test_backend_metadata_records_handles_backend_factory_error(monkeypatch):
-    from alcove.query import api as api_mod
+    from alcove.query.browse import backend_metadata_records
 
     monkeypatch.setattr("alcove.index.embedder.get_embedder", object)
     monkeypatch.setattr("alcove.index.backend.get_backend", lambda embedder: (_ for _ in ()).throw(RuntimeError("no db")))
 
-    assert api_mod._backend_metadata_records() == []
-
-
-def test_backend_metadata_records_handles_multi_collection_backend(monkeypatch):
-    from alcove.query import api as api_mod
-
-    class DummyCollection:
-        name = "science"
-
-        def get(self, include):
-            return {"metadatas": [{"source": "data/raw/paper.md"}]}
-
-    class BrokenCollection:
-        name = "broken"
-
-        def get(self, include):
-            raise RuntimeError("unavailable")
-
-    class DummyBackend:
-        def _get_all_collections(self):
-            return [DummyCollection(), BrokenCollection()]
-
-    monkeypatch.setattr("alcove.index.embedder.get_embedder", object)
-    monkeypatch.setattr("alcove.index.backend.get_backend", lambda embedder: DummyBackend())
-
-    assert api_mod._backend_metadata_records() == [{"source": "data/raw/paper.md", "collection": "science"}]
-
-
-def test_backend_metadata_records_handles_zvec_collection_cache(monkeypatch):
-    from alcove.query import api as api_mod
-
-    class DummyCollection:
-        def get(self, include):
-            return {"metadatas": [{"source": "data/raw/cache.md"}]}
-
-    class BrokenCollection:
-        def get(self, include):
-            raise RuntimeError("unavailable")
-
-    class DummyBackend:
-        _cols = [("cache", object(), DummyCollection()), ("broken", object(), BrokenCollection())]
-
-    monkeypatch.setattr("alcove.index.embedder.get_embedder", object)
-    monkeypatch.setattr("alcove.index.backend.get_backend", lambda embedder: DummyBackend())
-
-    assert api_mod._backend_metadata_records() == [{"source": "data/raw/cache.md", "collection": "cache"}]
+    assert backend_metadata_records() == []
 
 
 def test_browse_helpers_handle_fallbacks(tmp_path, monkeypatch):
-    from alcove.query import api as api_mod
+    from alcove.query import browse as browse_mod
 
     raw_dir = tmp_path / "raw"
     source = raw_dir / "letters" / "note.txt"
@@ -314,16 +248,16 @@ def test_browse_helpers_handle_fallbacks(tmp_path, monkeypatch):
     source.write_text("hello", encoding="utf-8")
     monkeypatch.setenv("RAW_DIR", str(raw_dir))
 
-    assert api_mod._source_key({"title": "Untitled"}) == "Untitled"
-    assert api_mod._source_key({}) == "(unknown)"
-    assert api_mod._source_label("(unknown)") == "Unknown source"
-    assert api_mod._source_label(str(source)) == "letters/note.txt"
-    assert api_mod._source_label("/external/archive/note.txt") == "archive/note.txt"
-    assert api_mod._source_label("") == "Unknown source"
-    assert api_mod._collection_label({}, str(source)) == "letters"
-    assert api_mod._collection_label({}, "/external/note.txt") == "default"
-    assert api_mod._document_sort_time("missing.txt", [{"uploaded_at": "not-a-date"}]) == 0.0
-    assert api_mod._document_sort_time(str(source), [{}]) > 0
+    assert browse_mod.source_key({"title": "Untitled"}) == "Untitled"
+    assert browse_mod.source_key({}) == "(unknown)"
+    assert browse_mod.source_label("(unknown)") == "Unknown source"
+    assert browse_mod.source_label(str(source)) == "letters/note.txt"
+    assert browse_mod.source_label("/external/archive/note.txt") == "archive/note.txt"
+    assert browse_mod.source_label("") == "Unknown source"
+    assert browse_mod.collection_label({}, str(source)) == "letters"
+    assert browse_mod.collection_label({}, "/external/note.txt") == "default"
+    assert browse_mod.document_sort_time("missing.txt", [{"uploaded_at": "not-a-date"}]) == 0.0
+    assert browse_mod.document_sort_time(str(source), [{}]) > 0
 
 
 def test_root_backend_exception_still_renders_html():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -229,7 +229,7 @@ def test_backend_metadata_records_handles_collection_backend(monkeypatch):
     class DummyBackend:
         _collection = DummyCollection()
 
-    monkeypatch.setattr("alcove.index.embedder.get_embedder", lambda: object())
+    monkeypatch.setattr("alcove.index.embedder.get_embedder", object)
     monkeypatch.setattr("alcove.index.backend.get_backend", lambda embedder: DummyBackend())
 
     assert api_mod._backend_metadata_records() == [{"source": "data/raw/a.md"}, {"source": "data/raw/b.md"}]
@@ -245,7 +245,7 @@ def test_backend_metadata_records_handles_collection_errors(monkeypatch):
     class DummyBackend:
         _collection = BrokenCollection()
 
-    monkeypatch.setattr("alcove.index.embedder.get_embedder", lambda: object())
+    monkeypatch.setattr("alcove.index.embedder.get_embedder", object)
     monkeypatch.setattr("alcove.index.backend.get_backend", lambda embedder: DummyBackend())
 
     assert api_mod._backend_metadata_records() == []
@@ -254,7 +254,7 @@ def test_backend_metadata_records_handles_collection_errors(monkeypatch):
 def test_backend_metadata_records_handles_backend_factory_error(monkeypatch):
     from alcove.query import api as api_mod
 
-    monkeypatch.setattr("alcove.index.embedder.get_embedder", lambda: object())
+    monkeypatch.setattr("alcove.index.embedder.get_embedder", object)
     monkeypatch.setattr("alcove.index.backend.get_backend", lambda embedder: (_ for _ in ()).throw(RuntimeError("no db")))
 
     assert api_mod._backend_metadata_records() == []
@@ -279,7 +279,7 @@ def test_backend_metadata_records_handles_multi_collection_backend(monkeypatch):
         def _get_all_collections(self):
             return [DummyCollection(), BrokenCollection()]
 
-    monkeypatch.setattr("alcove.index.embedder.get_embedder", lambda: object())
+    monkeypatch.setattr("alcove.index.embedder.get_embedder", object)
     monkeypatch.setattr("alcove.index.backend.get_backend", lambda embedder: DummyBackend())
 
     assert api_mod._backend_metadata_records() == [{"source": "data/raw/paper.md", "collection": "science"}]
@@ -299,7 +299,7 @@ def test_backend_metadata_records_handles_zvec_collection_cache(monkeypatch):
     class DummyBackend:
         _cols = [("cache", object(), DummyCollection()), ("broken", object(), BrokenCollection())]
 
-    monkeypatch.setattr("alcove.index.embedder.get_embedder", lambda: object())
+    monkeypatch.setattr("alcove.index.embedder.get_embedder", object)
     monkeypatch.setattr("alcove.index.backend.get_backend", lambda embedder: DummyBackend())
 
     assert api_mod._backend_metadata_records() == [{"source": "data/raw/cache.md", "collection": "cache"}]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -192,6 +192,18 @@ def test_browse_corpus_stats_groups_source_documents(monkeypatch):
     assert all("/tmp/alcove-corpus" not in item["label"] for item in stats["recent"])
 
 
+def test_browse_corpus_stats_empty_records():
+    from alcove.query.browse import browse_corpus_stats
+
+    assert browse_corpus_stats([]) == {
+        "collections": [],
+        "filetypes": [],
+        "authors": [],
+        "years": [],
+        "recent": [],
+    }
+
+
 def test_browse_page_renders_facets(monkeypatch):
     """GET /browse renders recent documents, collections, and facet chips."""
     from alcove.query import api as api_mod
@@ -244,8 +256,10 @@ def test_browse_helpers_handle_fallbacks(tmp_path, monkeypatch):
 
     raw_dir = tmp_path / "raw"
     source = raw_dir / "letters" / "note.txt"
+    root_source = raw_dir / "root.txt"
     source.parent.mkdir(parents=True)
     source.write_text("hello", encoding="utf-8")
+    root_source.write_text("root", encoding="utf-8")
     monkeypatch.setenv("RAW_DIR", str(raw_dir))
 
     assert browse_mod.source_key({"title": "Untitled"}) == "Untitled"
@@ -253,8 +267,10 @@ def test_browse_helpers_handle_fallbacks(tmp_path, monkeypatch):
     assert browse_mod.source_label("(unknown)") == "Unknown source"
     assert browse_mod.source_label(str(source)) == "letters/note.txt"
     assert browse_mod.source_label("/external/archive/note.txt") == "archive/note.txt"
+    assert browse_mod.source_label("note.txt") == "note.txt"
     assert browse_mod.source_label("") == "Unknown source"
     assert browse_mod.collection_label({}, str(source)) == "letters"
+    assert browse_mod.collection_label({}, str(root_source)) == "default"
     assert browse_mod.collection_label({}, "/external/note.txt") == "default"
     assert browse_mod.document_sort_time("missing.txt", [{"uploaded_at": "not-a-date"}]) == 0.0
     assert browse_mod.document_sort_time(str(source), [{}]) > 0

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -93,6 +93,76 @@ class TestChromaBackend:
         ]
 
 
+class _MetadataCollection:
+    def __init__(self, name="docs", metadatas=None, *, raises=False):
+        self.name = name
+        self._metadatas = metadatas or []
+        self._raises = raises
+
+    def get(self, include):
+        assert include == ["metadatas"]
+        if self._raises:
+            raise RuntimeError("unavailable")
+        return {"metadatas": self._metadatas}
+
+
+def test_multi_chroma_iter_metadata_records_enriches_collection():
+    from alcove.index.backend import MultiChromaBackend
+
+    backend = MultiChromaBackend.__new__(MultiChromaBackend)
+    backend._get_all_collections = lambda: [
+        _MetadataCollection("science", [{"source": "paper.md"}, None]),
+        _MetadataCollection("broken", raises=True),
+    ]
+
+    assert backend.iter_metadata_records() == [{"source": "paper.md", "collection": "science"}]
+
+
+def test_multi_root_iter_metadata_records_enriches_collection():
+    from alcove.index.backend import MultiRootBackend
+
+    backend = MultiRootBackend.__new__(MultiRootBackend)
+    backend._cols = [
+        ("letters", object(), _MetadataCollection(metadatas=[{"source": "note.txt"}])),
+    ]
+
+    assert backend.iter_metadata_records() == [{"source": "note.txt", "collection": "letters"}]
+
+
+class _ZvecMetadataDoc:
+    def __init__(self, **fields):
+        self._fields = fields
+
+    def field(self, name):
+        return self._fields.get(name)
+
+
+class _ZvecMetadataCollection:
+    def __init__(self, docs):
+        self._docs = docs
+
+    def query(self, vectors, topk, output_fields):
+        assert vectors is None
+        assert output_fields == ["source", "collection"]
+        return self._docs[:topk]
+
+
+def test_zvec_iter_metadata_records_returns_source_and_collection():
+    from alcove.index.backend import ZvecBackend
+
+    backend = ZvecBackend.__new__(ZvecBackend)
+    backend._collection = _ZvecMetadataCollection([
+        _ZvecMetadataDoc(source="a.txt", collection="letters"),
+        _ZvecMetadataDoc(source="b.txt"),
+    ])
+    backend.count = lambda: 2
+
+    assert backend.iter_metadata_records() == [
+        {"source": "a.txt", "collection": "letters"},
+        {"source": "b.txt", "collection": "default"},
+    ]
+
+
 @_skip_zvec
 class TestZvecBackend:
     def test_add_and_count(self, embedder, tmp_path, monkeypatch):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -74,6 +74,24 @@ class TestChromaBackend:
         )
         assert backend.count() == 1
 
+    def test_iter_metadata_records_returns_stored_metadata(self, embedder, tmp_path, monkeypatch):
+        monkeypatch.setenv("CHROMA_PATH", str(tmp_path / "chroma"))
+        monkeypatch.setenv("CHROMA_COLLECTION", "test_col")
+        from alcove.index.backend import ChromaBackend
+
+        backend = ChromaBackend(embedder)
+        vecs = embedder.embed(["hello world"])
+        backend.add(
+            ids=["doc1"],
+            embeddings=vecs,
+            documents=["hello world"],
+            metadatas=[{"source": "a.txt", "collection": "letters", "author": "Ada"}],
+        )
+
+        assert backend.iter_metadata_records() == [
+            {"source": "a.txt", "collection": "letters", "author": "Ada"}
+        ]
+
 
 @_skip_zvec
 class TestZvecBackend:


### PR DESCRIPTION
## Summary
- add a read-only `/browse` page for recent indexed documents and local corpus facets
- add primary Search/Browse navigation in the web UI
- update tests, CHANGELOG, and ROADMAP for the browse-mode slice

## Scope notes
- intentionally excludes private unified-doc mapping and file deletion/file-management behavior
- labels source documents without exposing full absolute local paths when possible

## Verification
- `python3 -m pytest tests/test_api.py tests/test_public_docs_hygiene.py -q`
- `python3 -m pytest`
- privacy scan of changed files found no private deployment, host, token, or PII strings

Draft until reviewed by John.
