### PR TITLE
Add release packaging checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to alcove-search.
 
 - Add read-only browse document detail pages with stable IDs and chunk previews.
 - Add a read-only browse mode for recent indexed documents, collections, file types, authors, and years.
+- Add release packaging checks for public metadata, release workflows, and Homebrew formula safety.
 - Add `EMBEDDER=ollama` for local Ollama embedding models.
 - Add built-in PPTX text extraction and pipeline dispatch.
 - Add local Ed25519 signing helpers and a standalone index signing tool for provenance checks.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -9,6 +9,7 @@ Use this checklist for public Alcove releases.
 3. Update `CHANGELOG.md` with user-visible changes and scope boundaries.
 4. Confirm docs avoid internal-only deployment details and private repo references.
 5. Verify package metadata and public links point to `Spitfire-Cowboy/alcove`.
+6. Run `python3 scripts/check_release_packaging.py`.
 
 ## Release
 
@@ -25,6 +26,12 @@ Use this checklist for public Alcove releases.
 2. Confirm docs site/demo links are still valid.
 3. Confirm release notes and roadmap language match shipped behavior.
 4. Open follow-up issues for deferred items.
+
+## Packaging notes
+
+- PyPI is the supported public package channel.
+- Do not add a Homebrew formula until the formula has public URLs, Apache-2.0 metadata, a real release SHA, and vendored Python resources suitable for offline Homebrew installs.
+- If a `Formula/alcove.rb` file is added, `scripts/check_release_packaging.py` must pass before release.
 
 ## Public-safety guardrails
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,6 +20,8 @@ This is the foundation. Everything below builds on it.
 
 **MCP endpoint.** This is the "share it with the universe" part. An MCP-compatible retrieval surface lets AI tools, public-facing websites, or any other tool query your index. The first public step is a local STDIO MCP server that exposes search and collection-listing tools. Your corpus stays local. Your index stays yours. The answers are available to whoever you choose to expose them to. Because Alcove is retrieval, not generation, those answers are what your documents actually say: no hallucinations, no editorializing, no slop. [MCP changes the security surface](SECURITY.md#security-model); review it before exposing the endpoint. Context7 compatibility is a goal.
 
+**Release packaging hygiene.** Public releases now include checks for package metadata, release automation, and Homebrew formula safety. PyPI remains the supported public install channel; Homebrew packaging stays deferred until the formula can be generated with public URLs, Apache-2.0 metadata, real release hashes, and vendored Python resources.
+
 **Streaming ingest.** Watch a directory and re-index on change. The current pipeline is batch-oriented: you run `alcove ingest`, it processes everything. Streaming mode keeps the index current without manual intervention.
 
 **Provenance and index signing.** Local signing should let operators publish or move index exports with tamper-evident metadata. The first step is Ed25519 signing and verification for document hashes and index export envelopes. Signature verification proves integrity against a public key; identity trust still depends on the operator pinning or verifying the key fingerprint out of band.

--- a/scripts/check_release_packaging.py
+++ b/scripts/check_release_packaging.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+BANNED_MARKERS = ("/Users/",)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _project_version(pyproject_text: str) -> str:
+    match = re.search(r'^version = "([^"]+)"$', pyproject_text, re.MULTILINE)
+    if not match:
+        raise AssertionError("pyproject.toml is missing project version")
+    return match.group(1)
+
+
+def check_pyproject(root: Path = REPO_ROOT) -> list[str]:
+    text = _read(root / "pyproject.toml")
+    checks = {
+        'name = "alcove-search"': "package name is alcove-search",
+        'license = {text = "Apache-2.0"}': "package license is Apache-2.0",
+        'Repository = "https://github.com/Spitfire-Cowboy/alcove"': (
+            "repository URL is public"
+        ),
+        'Homepage = "https://spitfire-cowboy.github.io/alcove/"': (
+            "homepage URL is public docs site"
+        ),
+        'alcove = "alcove.cli:main"': "CLI entry point is declared",
+    }
+    missing = [description for marker, description in checks.items() if marker not in text]
+    if missing:
+        raise AssertionError("pyproject.toml failed checks: " + ", ".join(missing))
+    return list(checks.values())
+
+
+def check_release_workflows(root: Path = REPO_ROOT) -> list[str]:
+    required = [
+        root / ".github" / "workflows" / "release.yml",
+        root / ".github" / "workflows" / "publish.yml",
+    ]
+    missing = [str(path.relative_to(root)) for path in required if not path.exists()]
+    if missing:
+        raise AssertionError("missing release workflow(s): " + ", ".join(missing))
+    return ["release workflow exists", "PyPI publish workflow exists"]
+
+
+def check_homebrew_formula(root: Path = REPO_ROOT) -> list[str]:
+    formula = root / "Formula" / "alcove.rb"
+    if not formula.exists():
+        return ["no Homebrew formula present; public release path is PyPI-only"]
+
+    formula_text = _read(formula)
+    pyproject_text = _read(root / "pyproject.toml")
+    version = _project_version(pyproject_text)
+    expected_sdist = f"alcove_search-{version}.tar.gz"
+    required = {
+        'homepage "https://github.com/Spitfire-Cowboy/alcove"': (
+            "Homebrew homepage is public repo"
+        ),
+        'license "Apache-2.0"': "Homebrew license matches package metadata",
+        expected_sdist: "Homebrew sdist URL matches pyproject version",
+    }
+
+    failures = [
+        description for marker, description in required.items() if marker not in formula_text
+    ]
+    banned_hits = [marker for marker in BANNED_MARKERS if marker in formula_text]
+    if "REPLACE_WITH_RELEASE_SHA256" in formula_text:
+        banned_hits.append("REPLACE_WITH_RELEASE_SHA256")
+    if re.search(r'sha256 "[0-9a-f]{64}"', formula_text) is None:
+        failures.append("Homebrew formula has a real sha256")
+
+    if failures or banned_hits:
+        details = []
+        if failures:
+            details.append("failed checks: " + ", ".join(failures))
+        if banned_hits:
+            details.append("blocked marker(s): " + ", ".join(banned_hits))
+        raise AssertionError("Formula/alcove.rb is not release-safe: " + "; ".join(details))
+
+    return list(required.values()) + ["Homebrew formula has a real sha256"]
+
+
+def run_checks(root: Path = REPO_ROOT) -> list[str]:
+    checks: list[str] = []
+    checks.extend(check_pyproject(root))
+    checks.extend(check_release_workflows(root))
+    checks.extend(check_homebrew_formula(root))
+    return checks
+
+
+def main() -> int:
+    try:
+        checks = run_checks()
+    except AssertionError as exc:
+        print(f"release packaging check failed: {exc}", file=sys.stderr)
+        return 1
+
+    for check in checks:
+        print(f"ok: {check}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_release_packaging.py"
+
+
+def _load_release_packaging_module():
+    spec = importlib.util.spec_from_file_location("check_release_packaging", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_public_release_packaging_checks_pass() -> None:
+    module = _load_release_packaging_module()
+
+    checks = module.run_checks(REPO_ROOT)
+
+    assert "package name is alcove-search" in checks
+    assert "package license is Apache-2.0" in checks
+    assert "release workflow exists" in checks
+    assert "PyPI publish workflow exists" in checks
+
+
+def test_unsafe_homebrew_formula_is_rejected(tmp_path: Path) -> None:
+    module = _load_release_packaging_module()
+    formula_dir = tmp_path / "Formula"
+    workflow_dir = tmp_path / ".github" / "workflows"
+    formula_dir.mkdir(parents=True)
+    workflow_dir.mkdir(parents=True)
+    (workflow_dir / "release.yml").write_text("name: release\n", encoding="utf-8")
+    (workflow_dir / "publish.yml").write_text("name: publish\n", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(
+        '\n'.join(
+            [
+                '[project]',
+                'name = "alcove-search"',
+                'version = "0.3.0"',
+                'license = {text = "Apache-2.0"}',
+                '',
+                '[project.urls]',
+                'Homepage = "https://spitfire-cowboy.github.io/alcove/"',
+                'Repository = "https://github.com/Spitfire-Cowboy/alcove"',
+                '',
+                '[project.scripts]',
+                'alcove = "alcove.cli:main"',
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (formula_dir / "alcove.rb").write_text(
+        '\n'.join(
+            [
+                "class Alcove < Formula",
+                '  homepage "https://example.invalid/internal/alcove"',
+                '  url "https://files.pythonhosted.org/packages/source/a/alcove-search/alcove_search-0.1.0.tar.gz"',
+                '  sha256 "REPLACE_WITH_RELEASE_SHA256"',
+                '  license "MIT"',
+                "end",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(AssertionError, match=r"Formula/alcove\.rb is not release-safe"):
+        module.run_checks(tmp_path)


### PR DESCRIPTION
## Summary
- add `scripts/check_release_packaging.py` for public package metadata and release workflow checks
- reject unsafe Homebrew formulas until URLs, license, hashes, and resources are release-ready
- update the release checklist, CHANGELOG, and ROADMAP

## Scope notes
- does not port the stale private Homebrew formula; the check documents why Homebrew remains deferred
- PyPI remains the supported public package channel

## Verification
- `python3 scripts/check_release_packaging.py`
- `python3 -m pytest tests/test_release_packaging.py tests/test_public_docs_hygiene.py -q`
- `python3 -m pytest`
- `python3 -m build`
- privacy scan of changed files found no private hostnames, deployment details, secrets, or PII strings

Draft until reviewed by John.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated release packaging validation to ensure metadata completeness, release workflow presence, and Homebrew safety guardrails.
* **Documentation**
  * Updated pre-release checklist and roadmap with a new packaging checks step and packaging notes (PyPI as supported public channel; Homebrew guarded).
* **Tests**
  * Added tests to verify packaging checks and to reject unsafe Homebrew formula scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Spitfire-Cowboy/alcove/pull/126)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->