### PR TITLE
Add browse document drill-down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to alcove-search.
 
 ## [Unreleased]
 
+- Add read-only browse document detail pages with stable IDs and chunk previews.
 - Add a read-only browse mode for recent indexed documents, collections, file types, authors, and years.
 - Add `EMBEDDER=ollama` for local Ollama embedding models.
 - Add built-in PPTX text extraction and pipeline dispatch.

--- a/alcove/index/backend.py
+++ b/alcove/index/backend.py
@@ -417,14 +417,20 @@ class ZvecBackend:
         results = self._collection.query(
             vectors=None,
             topk=self.count() or 1,
-            output_fields=["source", "collection"],
+            output_fields=["document", "source", "collection"],
         )
         records: List[Dict[str, object]] = []
         for doc in results:
-            records.append({
-                "source": doc.field("source"),
-                "collection": doc.field("collection") or "default",
-            })
+            records.append(
+                _enrich_metadata_record(
+                    {
+                        "source": doc.field("source"),
+                        "collection": doc.field("collection") or "default",
+                    },
+                    document=doc.field("document"),
+                    chunk_id=doc.id,
+                )
+            )
         return records
 
 
@@ -434,19 +440,42 @@ def _collection_metadata_records(
     collection_name: str | None = None,
 ) -> List[Dict[str, object]]:
     try:
-        raw = collection.get(include=["metadatas"])
+        raw = collection.get(include=["metadatas", "documents"])
     except Exception:
         return []
 
+    documents = raw.get("documents") or []
+    ids = raw.get("ids") or []
     records: List[Dict[str, object]] = []
-    for meta in raw.get("metadatas") or []:
+    for index, meta in enumerate(raw.get("metadatas") or []):
         if not isinstance(meta, dict):
             continue
         record = dict(meta)
-        if collection_name:
-            record.setdefault("collection", collection_name)
-        records.append(record)
+        records.append(
+            _enrich_metadata_record(
+                record,
+                collection_name=collection_name,
+                document=documents[index] if index < len(documents) else None,
+                chunk_id=ids[index] if index < len(ids) else None,
+            )
+        )
     return records
+
+
+def _enrich_metadata_record(
+    record: Dict[str, object],
+    *,
+    collection_name: str | None = None,
+    document: object = None,
+    chunk_id: object = None,
+) -> Dict[str, object]:
+    if collection_name:
+        record.setdefault("collection", collection_name)
+    if isinstance(document, str):
+        record["__document"] = document
+    if isinstance(chunk_id, str):
+        record["__chunk_id"] = chunk_id
+    return record
 
 
 _BUILTIN_BACKENDS = {

--- a/alcove/query/api.py
+++ b/alcove/query/api.py
@@ -7,7 +7,7 @@ import re
 from pathlib import Path
 from typing import List, Optional
 
-from fastapi import FastAPI, Query, Request, UploadFile, File
+from fastapi import FastAPI, Query, Request, UploadFile, File, HTTPException
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
@@ -15,7 +15,7 @@ from starlette.templating import Jinja2Templates
 import uvicorn
 
 from alcove.web import TEMPLATES_DIR, STATIC_DIR
-from .browse import browse_corpus_stats
+from .browse import browse_corpus_stats, browse_document_detail
 from .retriever import query_hybrid, query_keyword, query_text
 
 app = FastAPI(title="Alcove")
@@ -270,6 +270,19 @@ def browse(request: Request):
         request,
         "browse.html",
         _tpl({"stats": stats, "total_docs": total_docs}),
+    )
+
+
+@app.get("/browse/document/{document_id}", response_class=HTMLResponse)
+def browse_document(request: Request, document_id: str):
+    """Render read-only details for one indexed source document."""
+    document = browse_document_detail(document_id)
+    if document is None:
+        raise HTTPException(status_code=404, detail="Document not found")
+    return templates.TemplateResponse(
+        request,
+        "browse_document.html",
+        _tpl({"document": document}),
     )
 
 

--- a/alcove/query/browse.py
+++ b/alcove/query/browse.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import os
 import re
 from collections import Counter
@@ -36,39 +37,32 @@ def browse_corpus_stats(records: list[dict[str, Any]] | None = None) -> dict[str
     if not records:
         return dict(EMPTY_BROWSE_STATS)
 
-    grouped: dict[str, list[dict[str, Any]]] = {}
-    for meta in records:
-        grouped.setdefault(source_key(meta), []).append(meta)
+    groups = source_groups(records)
+    documents = documents_from_groups(groups)
 
     collections: Counter[str] = Counter()
     filetypes: Counter[str] = Counter()
     authors: Counter[str] = Counter()
     years: Counter[str] = Counter()
-    recent: list[dict[str, Any]] = []
 
-    for source, metas in grouped.items():
-        first = metas[0]
-        label = source_label(source)
-        collection = collection_label(first, source)
-        collections[collection] += 1
+    # Collection and filetype counts use grouped source documents. Author and
+    # year facets below inspect raw metadata so chunks without text still count.
+    for document in documents:
+        collections[document["collection"]] += 1
 
-        ext = Path(label).suffix.lower().lstrip(".")
+        ext = Path(document["label"]).suffix.lower().lstrip(".")
         if ext:
             filetypes[ext.upper()] += 1
 
-        for author in metadata_authors(first):
+    for metas in groups.values():
+        meta = metas[0]
+
+        for author in metadata_authors(meta):
             authors[author] += 1
 
-        year = str(first.get("year") or "").strip()
+        year = str(meta.get("year") or "").strip()
         if re.fullmatch(r"\d{4}", year):
             years[year] += 1
-
-        recent.append({
-            "label": label,
-            "collection": collection,
-            "chunk_count": len(metas),
-            "sort_time": document_sort_time(source, metas),
-        })
 
     return {
         "collections": counted_items(collections, "name"),
@@ -78,8 +72,59 @@ def browse_corpus_stats(records: list[dict[str, Any]] | None = None) -> dict[str
             {"year": year, "doc_count": count}
             for year, count in sorted(years.items(), key=lambda item: item[0], reverse=True)
         ],
-        "recent": sorted(recent, key=lambda item: (-item["sort_time"], item["label"].lower()))[:12],
+        "recent": sorted(documents, key=lambda item: (-item["sort_time"], item["label"].lower()))[:12],
     }
+
+
+def browse_document_detail(
+    document_id: str,
+    records: list[dict[str, Any]] | None = None,
+) -> dict[str, Any] | None:
+    """Return one read-only source document entry by stable browse ID."""
+    records = backend_metadata_records() if records is None else records
+    for document in browse_documents(records):
+        if document["id"] == document_id:
+            return document
+    return None
+
+
+def browse_documents(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return documents_from_groups(source_groups(records))
+
+
+def source_groups(records: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for meta in records:
+        grouped.setdefault(source_key(meta), []).append(meta)
+    return grouped
+
+
+def documents_from_groups(groups: dict[str, list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    documents: list[dict[str, Any]] = []
+    for source, metas in groups.items():
+        first = metas[0]
+        documents.append(
+            {
+                "id": browse_document_id(source),
+                "label": source_label(source),
+                "collection": collection_label(first, source),
+                "chunk_count": len(metas),
+                "sort_time": document_sort_time(source, metas),
+                "chunks": document_chunks(metas),
+            }
+        )
+    return documents
+
+
+def document_chunks(metas: list[dict[str, Any]]) -> list[dict[str, str]]:
+    return [
+        {
+            "id": str(meta.get("__chunk_id") or ""),
+            "text": chunk_preview(str(meta.get("__document") or "")),
+        }
+        for meta in metas
+        if str(meta.get("__document") or "").strip()
+    ][:8]
 
 
 def counted_items(counter: Counter[str], key: str) -> list[dict[str, Any]]:
@@ -150,3 +195,14 @@ def document_sort_time(source: str, metas: list[dict[str, Any]]) -> float:
         return Path(source).expanduser().stat().st_mtime
     except OSError:
         return 0.0
+
+
+def browse_document_id(source: str) -> str:
+    return hashlib.sha256(source.encode("utf-8")).hexdigest()[:16]
+
+
+def chunk_preview(text: str, *, limit: int = 360) -> str:
+    normalized = re.sub(r"\s+", " ", text).strip()
+    if len(normalized) <= limit:
+        return normalized
+    return normalized[: limit - 1].rstrip() + "..."

--- a/alcove/web/static/style.css
+++ b/alcove/web/static/style.css
@@ -778,11 +778,28 @@ button:focus-visible {
   white-space: nowrap;
 }
 
+a.browse-list-title {
+  text-decoration: underline;
+  text-underline-offset: 0.12em;
+}
+
+a.browse-list-title:hover {
+  color: var(--gold);
+  text-decoration-thickness: 2px;
+}
+
 .browse-list-meta {
   display: block;
   color: var(--text-muted);
   font-size: 0.8rem;
   margin-top: 0.1rem;
+}
+
+.browse-chunk-preview p {
+  color: var(--text-excerpt);
+  font-size: 0.92rem;
+  line-height: 1.55;
+  margin-top: 0.35rem;
 }
 
 .browse-chips {

--- a/alcove/web/templates/browse.html
+++ b/alcove/web/templates/browse.html
@@ -34,7 +34,11 @@
       <div class="browse-list">
         {% for doc in stats.recent %}
         <div class="browse-list-item">
+          {% if doc.id %}
+          <a class="browse-list-title" href="{{ base_url }}/browse/document/{{ doc.id | e }}" title="{{ doc.label | e }}">{{ doc.label | e }}</a>
+          {% else %}
           <span class="browse-list-title" title="{{ doc.label | e }}">{{ doc.label | e }}</span>
+          {% endif %}
           <span class="browse-list-meta">{{ doc.collection | e }} &middot; {{ doc.chunk_count }} chunk{% if doc.chunk_count != 1 %}s{% endif %}</span>
         </div>
         {% endfor %}

--- a/alcove/web/templates/browse_document.html
+++ b/alcove/web/templates/browse_document.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <section class="browse-hero" aria-labelledby="document-heading">
+    <div>
+      <p class="section-kicker">Document detail</p>
+      <h2 id="document-heading">{{ document.label | e }}</h2>
+      <p>{{ document.collection | e }} &middot; {{ document.chunk_count }} indexed chunk{% if document.chunk_count != 1 %}s{% endif %}</p>
+    </div>
+    <form class="browse-search" method="GET" action="{{ base_url }}/search" role="search">
+      <label class="sr-only" for="document-search-input">Search within {{ document.collection | e }}</label>
+      <input id="document-search-input" type="text" name="q" placeholder="Search {{ document.collection | e }} collection">
+      <input type="hidden" name="collections" value="{{ document.collection | e }}">
+      <button class="search-btn" type="submit">Search</button>
+    </form>
+  </section>
+
+  <section class="browse-panel browse-panel-wide" aria-labelledby="chunk-preview-heading">
+    <div class="browse-panel-heading">
+      <h3 id="chunk-preview-heading">Chunk previews</h3>
+    </div>
+    {% if document.chunks %}
+    <div class="browse-list">
+      {% for chunk in document.chunks %}
+      <article class="browse-list-item browse-chunk-preview">
+        {% if chunk.id %}
+        <span class="browse-list-meta">{{ chunk.id | e }}</span>
+        {% endif %}
+        <p>{{ chunk.text | e }}</p>
+      </article>
+      {% endfor %}
+    </div>
+    {% else %}
+    <p class="empty-state">This backend exposed metadata for the document, but not chunk text.</p>
+    {% endif %}
+  </section>
+
+  <a class="back-link" href="{{ base_url }}/browse">&#8592; Back to browse</a>
+{% endblock %}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -59,7 +59,9 @@ Browse mode is a core, read-only view over indexed metadata. It does not inspect
 raw corpus files directly and does not mutate the index. Backends expose stored
 metadata through `iter_metadata_records()`, and `alcove/query/browse.py`
 aggregates that metadata into source-document facets such as collection, file
-type, author, year, and recent documents.
+type, author, year, and recent documents. Backends may also include stored chunk
+text in internal `__document` fields and chunk IDs in `__chunk_id` fields so the
+web UI can show document drill-down previews without reading raw files.
 
 Backend plugins should implement `iter_metadata_records()` when they want the
 core web UI's `/browse` page to show corpus facets. If a backend cannot enumerate

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@ This is the foundation. Everything below builds on it.
 
 **Semantic search as default.** The hash embedder exists for zero-download offline bootstrapping and for operators who do not want ML in the pipeline. Once the onboarding experience is smooth enough, sentence-transformers (or a lighter alternative) becomes the default install. The hash embedder stays available: not a stepping stone, but a permanent option for people who want deterministic, inspectable results.
 
-**Browse mode.** Alcove is now navigable, not just searchable: the web UI includes a read-only browse page for recent indexed documents, collections, file types, authors, and years. Next steps are deeper directory-aware browsing and document-level drill-down while keeping the surface retrieval-only.
+**Browse mode.** Alcove is now navigable, not just searchable: the web UI includes read-only browse pages for recent indexed documents, document detail, collections, file types, authors, and years. Next steps are deeper directory-aware browsing while keeping the surface retrieval-only.
 
 **Local model hooks.** `EMBEDDER=ollama` now lets operators point Alcove at a local Ollama server for embeddings. Near-term work is documentation polish and model-specific guidance, not hosted inference or generated answers.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -171,6 +171,8 @@ def test_browse_corpus_stats_groups_source_documents(monkeypatch):
             "collection": "science",
             "authors": "Einstein, A.",
             "year": "1905",
+            "__document": "Relativity chunk one.",
+            "__chunk_id": "chunk-1",
         },
         {
             "source": "/tmp/alcove-corpus/science/einstein.pdf",
@@ -190,6 +192,9 @@ def test_browse_corpus_stats_groups_source_documents(monkeypatch):
     assert stats["authors"] == [{"name": "Einstein, A.", "doc_count": 1}]
     assert {"year": "1905", "doc_count": 1} in stats["years"]
     assert all("/tmp/alcove-corpus" not in item["label"] for item in stats["recent"])
+    science_doc = next(item for item in stats["recent"] if item["collection"] == "science")
+    assert science_doc["id"]
+    assert science_doc["chunks"] == [{"id": "chunk-1", "text": "Relativity chunk one."}]
 
 
 def test_browse_corpus_stats_empty_records():
@@ -218,6 +223,7 @@ def test_browse_page_renders_facets(monkeypatch):
                 "collection": "research",
                 "authors": "Ada Lovelace",
                 "year": "1843",
+                "__document": "Analytical engine notes.",
             }
         ]),
     )
@@ -225,8 +231,49 @@ def test_browse_page_renders_facets(monkeypatch):
     assert r.status_code == 200
     assert "Recent Documents" in r.text
     assert "paper.md" in r.text
+    assert "/browse/document/" in r.text
     assert "research" in r.text
     assert "Ada Lovelace" in r.text
+
+
+def test_browse_document_detail_renders_chunk_previews(monkeypatch):
+    from alcove.query import browse as browse_mod
+
+    records = [
+        {
+            "source": "/tmp/private/path/research/paper.md",
+            "collection": "research",
+            "__chunk_id": "chunk-1",
+            "__document": "First chunk with enough text to preview.",
+        },
+        {
+            "source": "/tmp/private/path/research/paper.md",
+            "collection": "research",
+            "__chunk_id": "chunk-2",
+            "__document": "Second chunk preview.",
+        },
+    ]
+    monkeypatch.setattr(browse_mod, "backend_metadata_records", lambda: records)
+    doc_id = browse_mod.browse_corpus_stats(records)["recent"][0]["id"]
+    assert browse_mod.browse_document_detail("not-found", records) is None
+
+    r = client.get(f"/browse/document/{doc_id}")
+
+    assert r.status_code == 200
+    assert "Document detail" in r.text
+    assert "research/paper.md" in r.text
+    assert "/tmp/private/path" not in r.text
+    assert "First chunk with enough text to preview." in r.text
+    assert "chunk-2" in r.text
+
+
+def test_browse_document_detail_404(monkeypatch):
+    from alcove.query import api as api_mod
+
+    monkeypatch.setattr(api_mod, "browse_document_detail", lambda _: None)
+    r = client.get("/browse/document/not-found")
+
+    assert r.status_code == 404
 
 
 def test_backend_metadata_records_uses_backend_public_interface(monkeypatch):
@@ -272,6 +319,9 @@ def test_browse_helpers_handle_fallbacks(tmp_path, monkeypatch):
     assert browse_mod.collection_label({}, str(source)) == "letters"
     assert browse_mod.collection_label({}, str(root_source)) == "default"
     assert browse_mod.collection_label({}, "/external/note.txt") == "default"
+    assert browse_mod.chunk_preview("hello\n\n  world") == "hello world"
+    assert browse_mod.chunk_preview("a" * 370).endswith("...")
+    assert browse_mod.browse_document_id("source.txt") == browse_mod.browse_document_id("source.txt")
     assert browse_mod.document_sort_time("missing.txt", [{"uploaded_at": "not-a-date"}]) == 0.0
     assert browse_mod.document_sort_time(str(source), [{}]) > 0
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -89,21 +89,29 @@ class TestChromaBackend:
         )
 
         assert backend.iter_metadata_records() == [
-            {"source": "a.txt", "collection": "letters", "author": "Ada"}
+            {
+                "source": "a.txt",
+                "collection": "letters",
+                "author": "Ada",
+                "__document": "hello world",
+                "__chunk_id": "doc1",
+            }
         ]
 
 
 class _MetadataCollection:
-    def __init__(self, name="docs", metadatas=None, *, raises=False):
+    def __init__(self, name="docs", metadatas=None, documents=None, ids=None, *, raises=False):
         self.name = name
         self._metadatas = metadatas or []
+        self._documents = documents or []
+        self._ids = ids or []
         self._raises = raises
 
     def get(self, include):
-        assert include == ["metadatas"]
+        assert include == ["metadatas", "documents"]
         if self._raises:
             raise RuntimeError("unavailable")
-        return {"metadatas": self._metadatas}
+        return {"metadatas": self._metadatas, "documents": self._documents, "ids": self._ids}
 
 
 def test_multi_chroma_iter_metadata_records_enriches_collection():
@@ -111,11 +119,13 @@ def test_multi_chroma_iter_metadata_records_enriches_collection():
 
     backend = MultiChromaBackend.__new__(MultiChromaBackend)
     backend._get_all_collections = lambda: [
-        _MetadataCollection("science", [{"source": "paper.md"}, None]),
+        _MetadataCollection("science", [{"source": "paper.md"}, None], ["body"], ["chunk-1"]),
         _MetadataCollection("broken", raises=True),
     ]
 
-    assert backend.iter_metadata_records() == [{"source": "paper.md", "collection": "science"}]
+    assert backend.iter_metadata_records() == [
+        {"source": "paper.md", "collection": "science", "__document": "body", "__chunk_id": "chunk-1"}
+    ]
 
 
 def test_multi_root_iter_metadata_records_enriches_collection():
@@ -123,14 +133,17 @@ def test_multi_root_iter_metadata_records_enriches_collection():
 
     backend = MultiRootBackend.__new__(MultiRootBackend)
     backend._cols = [
-        ("letters", object(), _MetadataCollection(metadatas=[{"source": "note.txt"}])),
+        ("letters", object(), _MetadataCollection(metadatas=[{"source": "note.txt"}], documents=["note body"])),
     ]
 
-    assert backend.iter_metadata_records() == [{"source": "note.txt", "collection": "letters"}]
+    assert backend.iter_metadata_records() == [
+        {"source": "note.txt", "collection": "letters", "__document": "note body"}
+    ]
 
 
 class _ZvecMetadataDoc:
-    def __init__(self, **fields):
+    def __init__(self, id_="doc-id", **fields):
+        self.id = id_
         self._fields = fields
 
     def field(self, name):
@@ -143,7 +156,7 @@ class _ZvecMetadataCollection:
 
     def query(self, vectors, topk, output_fields):
         assert vectors is None
-        assert output_fields == ["source", "collection"]
+        assert output_fields == ["document", "source", "collection"]
         return self._docs[:topk]
 
 
@@ -152,14 +165,14 @@ def test_zvec_iter_metadata_records_returns_source_and_collection():
 
     backend = ZvecBackend.__new__(ZvecBackend)
     backend._collection = _ZvecMetadataCollection([
-        _ZvecMetadataDoc(source="a.txt", collection="letters"),
-        _ZvecMetadataDoc(source="b.txt"),
+        _ZvecMetadataDoc(id_="a-1", source="a.txt", collection="letters", document="A body"),
+        _ZvecMetadataDoc(id_="b-1", source="b.txt"),
     ])
     backend.count = lambda: 2
 
     assert backend.iter_metadata_records() == [
-        {"source": "a.txt", "collection": "letters"},
-        {"source": "b.txt", "collection": "default"},
+        {"source": "a.txt", "collection": "letters", "__document": "A body", "__chunk_id": "a-1"},
+        {"source": "b.txt", "collection": "default", "__chunk_id": "b-1"},
     ]
 
 


### PR DESCRIPTION
## What does this PR do?

Adds read-only `/browse/document/{id}` detail pages for source documents in browse mode. Recent documents now link to stable hashed document IDs, and detail pages show chunk previews when the backend exposes indexed chunk text through the public browse adapter.

## Why?

Browse mode should let operators inspect indexed source documents without exposing absolute local paths, reading raw corpus files, or adding any file management behavior.

## How to test

- [x] `python3 -m pytest tests/test_api.py tests/test_backend.py tests/test_public_docs_hygiene.py -q` passes
- [x] `python3 -m pytest -q` passes
- [x] No coverage regressions expected; added coverage for the no-match document detail path
- [x] `git diff --check` passes

## Checklist

- [x] Changes are scoped to one concern
- [x] No secrets, PII, deployment details, or hardcoded local paths
- [x] Docs updated for the new browse drill-down behavior

## Anything else?

This PR is rebuilt on current `main`; it is no longer stacked on #125. Scope is generic public Alcove core only: no demo-specific, deployment-specific, or private app code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read-only document detail pages with stable browse IDs, chunk previews, and a scoped search form.
  * Recent documents now link to their individual pages when an ID is available.

* **Documentation**
  * Clarified browse mode behavior and chunk/id storage in architecture and roadmap docs.

* **Style**
  * Improved link underline and chunk preview text styling.

* **Tests**
  * Expanded UI and backend tests to cover document pages, chunk previews, ID stability, and 404 handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Spitfire-Cowboy/alcove/pull/127)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->