### PR TITLE
Add Homebrew formula scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to alcove-search.
 
+## [Unreleased]
+
+- Add a public-safe Homebrew formula template, generator, and validation tests.
+- Document that Homebrew packaging is preparatory and must not be advertised until a real formula installs successfully.
+
 ## [0.3.0] - 2026-03-07
 
 - Add theme toggle, fix WCAG AA contrast, update accessibility docs

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The full roadmap is in [docs/ROADMAP.md](docs/ROADMAP.md). Alcove will not becom
 
 ## Documentation
 
-[Why Alcove?](WHY.md) · [Architecture](docs/ARCHITECTURE.md) · [Operations](docs/OPERATIONS.md) · [Security](docs/SECURITY.md) · [Seed Corpus](docs/SEED_CORPUS.md) · [Roadmap](docs/ROADMAP.md) · [Plugin Ideas](docs/PLUGINS.md) · [Accessibility](ACCESSIBILITY.md)
+[Why Alcove?](WHY.md) · [Architecture](docs/ARCHITECTURE.md) · [Operations](docs/OPERATIONS.md) · [Security](docs/SECURITY.md) · [Seed Corpus](docs/SEED_CORPUS.md) · [Roadmap](docs/ROADMAP.md) · [Plugin Ideas](docs/PLUGINS.md) · [Homebrew Packaging](docs/HOMEBREW.md) · [Accessibility](ACCESSIBILITY.md)
 
 ## License
 

--- a/docs/HOMEBREW.md
+++ b/docs/HOMEBREW.md
@@ -1,0 +1,34 @@
+# Homebrew Packaging
+
+Alcove does not currently ship an installable Homebrew formula.
+
+This repository includes a public-safe formula template and generator so release work can prepare a formula only after a real release artifact exists. Do not publish a generated formula with placeholder checksums, private repository URLs, or local filesystem paths.
+
+## Generate a Formula
+
+1. Publish the Alcove release artifact.
+2. Download or inspect the released sdist checksum from the public artifact source.
+3. Generate the formula with the real checksum:
+
+```bash
+python3 scripts/generate_homebrew_formula.py \
+  --version 0.3.0 \
+  --sha256 <real-64-character-sdist-sha256> \
+  --output Formula/alcove-search.rb
+```
+
+4. Validate the generated formula:
+
+```bash
+python3 scripts/generate_homebrew_formula.py --check Formula/alcove-search.rb
+```
+
+The template lives at `packaging/homebrew/alcove-search.rb.template`. It is intentionally not a live formula because the repository should not claim Homebrew support until the formula is generated from a real public release and tested through Homebrew.
+
+## Safety Rules
+
+- Use only public release artifact URLs.
+- Use only the real SHA-256 for that exact artifact.
+- Do not commit generated formulas with placeholder values.
+- Do not reference private repositories, internal hostnames, local user paths, or deployment details.
+- Do not advertise Homebrew installation until `brew install` succeeds from the published formula.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -9,6 +9,7 @@ Use this checklist for public Alcove releases.
 3. Update `CHANGELOG.md` with user-visible changes and scope boundaries.
 4. Confirm docs avoid internal-only deployment details and private repo references.
 5. Verify package metadata and public links point to `Spitfire-Cowboy/alcove`.
+6. If preparing Homebrew packaging, generate the formula only after the public release artifact exists and use its real SHA-256.
 
 ## Release
 
@@ -18,6 +19,7 @@ Use this checklist for public Alcove releases.
    - `.github/workflows/publish.yml`
 3. Verify GitHub Release notes generated successfully.
 4. Verify PyPI publish completed successfully.
+5. If a Homebrew formula is part of this release, run `python3 scripts/generate_homebrew_formula.py --check <formula>` before publishing it.
 
 ## Post-release
 
@@ -25,9 +27,11 @@ Use this checklist for public Alcove releases.
 2. Confirm docs site/demo links are still valid.
 3. Confirm release notes and roadmap language match shipped behavior.
 4. Open follow-up issues for deferred items.
+5. Do not add Homebrew install instructions until `brew install` succeeds from the public formula.
 
 ## Public-safety guardrails
 
 - Do not include internal hostnames, private filesystem paths, or customer-specific instructions.
 - Keep scope and acceptance criteria explicit in issue/PR tracking.
 - Avoid release claims that are not already shipped and verified.
+- Never publish or document a Homebrew formula with placeholder checksums.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,6 +20,8 @@ This is the foundation. Everything below builds on it.
 
 **Streaming ingest.** Watch a directory and re-index on change. The current pipeline is batch-oriented: you run `alcove ingest`, it processes everything. Streaming mode keeps the index current without manual intervention.
 
+**Homebrew packaging.** The repository has a safe formula template and generator, but Homebrew is not a shipped install path yet. The next step is to generate a formula from a real public release artifact, validate the checksum, test `brew install`, and only then advertise Homebrew installation.
+
 ## Mid-term
 
 **Cross-modal indexing.** Audio transcription, image OCR, video keyframe extraction. The pipeline architecture already separates extraction from embedding; new modalities plug in as extractors that produce text chunks from non-text sources. Bioacoustics and field recordings are a motivating use case, not an afterthought.

--- a/packaging/homebrew/alcove-search.rb.template
+++ b/packaging/homebrew/alcove-search.rb.template
@@ -1,0 +1,19 @@
+class AlcoveSearch < Formula
+  include Language::Python::Virtualenv
+
+  desc "Local-first document retrieval"
+  homepage "https://spitfire-cowboy.github.io/alcove/"
+  url "https://files.pythonhosted.org/packages/source/a/alcove-search/alcove_search-{{VERSION}}.tar.gz"
+  sha256 "{{SHA256}}"
+  license "Apache-2.0"
+
+  depends_on "python@3.12"
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/alcove --version")
+  end
+end

--- a/scripts/generate_homebrew_formula.py
+++ b/scripts/generate_homebrew_formula.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import argparse
 import re
 import sys
-import tomllib
 from pathlib import Path
 
 
@@ -28,9 +27,14 @@ class FormulaError(ValueError):
 
 
 def project_version(pyproject_path: Path = REPO_ROOT / "pyproject.toml") -> str:
-    with pyproject_path.open("rb") as handle:
-        data = tomllib.load(handle)
-    return str(data["project"]["version"])
+    match = re.search(
+        r'^\[project\][\s\S]*?^version = "([^"]+)"$',
+        pyproject_path.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    if not match:
+        raise FormulaError("pyproject.toml is missing [project] version")
+    return match.group(1)
 
 
 def validate_version(version: str) -> None:

--- a/scripts/generate_homebrew_formula.py
+++ b/scripts/generate_homebrew_formula.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Generate or validate the Homebrew formula scaffold.
+
+This script deliberately refuses placeholder checksums. It is safe to keep the
+template in-tree, but a generated formula should only be published after the
+release artifact exists and its real SHA-256 has been verified.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_TEMPLATE = REPO_ROOT / "packaging" / "homebrew" / "alcove-search.rb.template"
+PRIVATE_REPO_RE = re.compile(r"github\.com/(?!Spitfire-Cowboy/alcove\b)[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+")
+LOCAL_HOME_PATH_RE = re.compile(r"/(?:Users|home)/[A-Za-z0-9_.-]+")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(?:[A-Za-z0-9_.+-]+)?$")
+
+
+class FormulaError(ValueError):
+    """Raised when formula input is not safe to publish."""
+
+
+def project_version(pyproject_path: Path = REPO_ROOT / "pyproject.toml") -> str:
+    with pyproject_path.open("rb") as handle:
+        data = tomllib.load(handle)
+    return str(data["project"]["version"])
+
+
+def validate_version(version: str) -> None:
+    if not VERSION_RE.fullmatch(version):
+        raise FormulaError(f"invalid version: {version!r}")
+
+
+def validate_sha256(sha256: str) -> str:
+    normalized = sha256.strip().lower()
+    if not SHA256_RE.fullmatch(normalized):
+        raise FormulaError("sha256 must be exactly 64 lowercase or uppercase hex characters")
+    if len(set(normalized)) == 1:
+        raise FormulaError("sha256 appears to be a placeholder")
+    return normalized
+
+
+def validate_public_text(text: str) -> None:
+    unresolved = re.findall(r"{{[A-Z0-9_]+}}", text)
+    if unresolved:
+        raise FormulaError(f"formula has unresolved template tokens: {', '.join(sorted(set(unresolved)))}")
+    if PRIVATE_REPO_RE.search(text):
+        raise FormulaError("formula contains a non-canonical GitHub repository URL")
+    if LOCAL_HOME_PATH_RE.search(text):
+        raise FormulaError("formula contains a local home-directory path")
+    if re.search(r"sha256\s+\"(?:0{64}|f{64})\"", text, flags=re.IGNORECASE):
+        raise FormulaError("formula contains a placeholder sha256")
+    if "Spitfire-Cowboy/alcove" not in text and "alcove_search-" not in text:
+        raise FormulaError("formula does not point at the public Alcove release artifact")
+
+
+def render_formula(version: str, sha256: str, template_path: Path = DEFAULT_TEMPLATE) -> str:
+    validate_version(version)
+    safe_sha = validate_sha256(sha256)
+    text = template_path.read_text(encoding="utf-8")
+    rendered = text.replace("{{VERSION}}", version).replace("{{SHA256}}", safe_sha)
+    validate_public_text(rendered)
+    return rendered
+
+
+def check_formula(path: Path) -> None:
+    validate_public_text(path.read_text(encoding="utf-8"))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate or validate Alcove's Homebrew formula.")
+    parser.add_argument("--template", type=Path, default=DEFAULT_TEMPLATE, help="Formula template path")
+    parser.add_argument("--version", default=project_version(), help="Release version to embed")
+    parser.add_argument("--sha256", help="Real SHA-256 of the released sdist")
+    parser.add_argument("--output", type=Path, help="Write generated formula to this path")
+    parser.add_argument("--check", type=Path, help="Validate an already generated formula")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.check:
+            check_formula(args.check)
+            return 0
+        if not args.sha256:
+            raise FormulaError("--sha256 is required; use the real released sdist checksum")
+        formula = render_formula(args.version, args.sha256, args.template)
+        if args.output:
+            args.output.write_text(formula, encoding="utf-8")
+        else:
+            sys.stdout.write(formula)
+        return 0
+    except FormulaError as exc:
+        parser.error(str(exc))
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_homebrew_formula.py
+++ b/tests/test_homebrew_formula.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "generate_homebrew_formula.py"
+REALISTIC_SHA = "2a9f3c4d5e6b718293a4b5c6d7e8f90123456789abcdef0123456789abcd1234"
+
+
+def _load_generator():
+    spec = importlib.util.spec_from_file_location("generate_homebrew_formula", SCRIPT_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_generator_requires_real_sha256() -> None:
+    generator = _load_generator()
+
+    with pytest.raises(generator.FormulaError):
+        generator.render_formula("0.3.0", "0" * 64)
+
+    with pytest.raises(generator.FormulaError):
+        generator.render_formula("0.3.0", "not-a-sha")
+
+
+def test_generator_renders_public_formula_without_unresolved_tokens() -> None:
+    generator = _load_generator()
+
+    formula = generator.render_formula("0.3.0", REALISTIC_SHA.upper())
+
+    assert "{{" not in formula
+    assert "}}" not in formula
+    assert 'sha256 "2a9f3c4d5e6b718293a4b5c6d7e8f90123456789abcdef0123456789abcd1234"' in formula
+    assert "alcove_search-0.3.0.tar.gz" in formula
+    assert "github.com/example/private" not in formula
+    assert "/home/example" not in formula
+
+
+def test_formula_check_rejects_unresolved_template_tokens(tmp_path: Path) -> None:
+    generator = _load_generator()
+    formula = tmp_path / "alcove-search.rb"
+    formula.write_text(
+        'url "https://files.pythonhosted.org/packages/source/a/alcove-search/alcove_search-{{VERSION}}.tar.gz"\n'
+        'sha256 "{{SHA256}}"\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(generator.FormulaError):
+        generator.check_formula(formula)
+
+
+def test_formula_check_rejects_private_repo_and_local_paths(tmp_path: Path) -> None:
+    generator = _load_generator()
+
+    formula = tmp_path / "alcove-search.rb"
+    formula.write_text(
+        'homepage "https://github.com/example/private"\n'
+        'url "file:///home/example/alcove_search-0.3.0.tar.gz"\n'
+        f'sha256 "{REALISTIC_SHA}"\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(generator.FormulaError):
+        generator.check_formula(formula)


### PR DESCRIPTION
## Summary
- add a public-safe Homebrew formula template and generator
- reject placeholder checksums, private repository URLs, and local filesystem paths
- document that Homebrew is preparatory and must not be advertised until a generated formula installs successfully

## Scope notes
- does not add a live formula with a fake release hash
- PyPI remains the shipped public install channel until a real formula is generated and tested

## Verification
- `python3 -m pytest tests/test_homebrew_formula.py tests/test_public_docs_hygiene.py -q`
- `python3 scripts/generate_homebrew_formula.py --sha256 <realistic-sha> | python3 scripts/generate_homebrew_formula.py --check /dev/stdin`
- `python3 -m pytest`
- `git diff --check`

Draft until reviewed by John.
