### PR TITLE
Add 0.4.0 release plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to alcove-search.
 - Add read-only browse document detail pages with stable IDs and chunk previews.
 - Add a read-only browse mode for recent indexed documents, collections, file types, authors, and years.
 - Add release packaging checks for public metadata, release workflows, and Homebrew formula safety.
+- Add a public 0.4.0 release plan while keeping the package version at 0.3.0 until release.
 - Add `EMBEDDER=ollama` for local Ollama embedding models.
 - Add built-in PPTX text extraction and pipeline dispatch.
 - Add local Ed25519 signing helpers and a standalone index signing tool for provenance checks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ All notable changes to alcove-search.
 - Add a STDIO Model Context Protocol server for querying local Alcove indexes.
 - Add runtime configuration feature flags for environment and config-file controlled deployments.
 
+## [0.4.0] - Planned
+
+Planning status: not released, not tagged, and not reflected in package metadata.
+
+- Prepare a public release plan for a 0.4.0 feature-batch release.
+- Review pending feature PRs in dependency order before deciding final scope.
+- Keep release notes limited to merged, verified behavior at release time.
+- Keep the package version at 0.3.0 until the actual release commit.
+
 ## [0.3.0] - 2026-03-07
 
 - Add theme toggle, fix WCAG AA contrast, update accessibility docs

--- a/docs/RELEASE_0_4_0_PLAN.md
+++ b/docs/RELEASE_0_4_0_PLAN.md
@@ -1,0 +1,68 @@
+# Alcove 0.4.0 Release Plan
+
+Status: planning only. This document does not ship features, merge feature PRs, bump package metadata, create a tag, or publish artifacts.
+
+Target: 0.4.0 feature-batch release.
+
+Current package version: 0.3.0 until the release commit.
+
+## Scope Decision
+
+0.4.0 should be decided as a reviewed feature batch, not as a rolling collection of branch state. A feature belongs in 0.4.0 only after its PR has been reviewed, merged, tested on `main`, and documented as shipped behavior.
+
+Candidate areas to evaluate:
+
+- Retrieval surface improvements that preserve Alcove's retrieval-only contract.
+- Ingest and extractor improvements that keep data local by default.
+- Plugin-system improvements with clear entry-point compatibility notes.
+- Web or CLI usability improvements that are covered by focused tests.
+- Documentation updates that describe shipped behavior without promising unmerged work.
+
+Explicitly out of scope for this planning branch:
+
+- Version bump to 0.4.0 or 1.0.0.
+- Release tag creation.
+- Publishing to PyPI or package registries.
+- Private deployment notes, internal hostnames, private repository names, or operator-specific paths.
+
+## PR Review Sequence
+
+Use this sequence before cutting the release:
+
+1. Review dependency and maintenance PRs first so feature branches are evaluated against current dependencies.
+2. Review data-model, manifest, or plugin contract PRs before UI or documentation PRs that depend on those contracts.
+3. Review ingest and indexing changes before query/API changes that expose their output.
+4. Review user-facing CLI, API, and web changes after the underlying pipeline behavior is stable.
+5. Review documentation and changelog updates last, using only merged and verified behavior.
+
+Each accepted PR should leave behind enough evidence for release notes: tests run, public docs touched, and any compatibility notes. Deferred PRs should be listed as deferred follow-up work, not as 0.4.0 features.
+
+## Release Checklist
+
+Before release scope is approved:
+
+- [ ] Confirm every candidate feature PR is merged or explicitly deferred.
+- [ ] Confirm `main` passes CI for supported Python versions.
+- [ ] Run focused local tests for changed surfaces.
+- [ ] Confirm package metadata still points to the public project URLs.
+- [ ] Confirm no release docs include private hostnames, private repository references, personal filesystem paths, or PII.
+- [ ] Rewrite this plan's candidate language into final release notes for only merged behavior.
+
+At release time:
+
+- [ ] Bump package metadata from 0.3.0 to 0.4.0 in the release commit.
+- [ ] Move the 0.4.0 changelog entry from planned scope to dated shipped scope.
+- [ ] Tag `v0.4.0` only after tests and release notes are final.
+- [ ] Verify the published artifact and public release notes.
+
+After release:
+
+- [ ] Update `docs/ROADMAP.md` so 0.4.0 is described as current shipped behavior.
+- [ ] Open follow-up issues for deferred PRs and incomplete roadmap items.
+- [ ] Remove or archive this planning checklist if it no longer reflects the public release state.
+
+## Public-Safety Notes
+
+The release decision should be reproducible from public project state. Do not include private branch names, private repository slugs, operator-specific directories, internal deployment hosts, credentials, access tokens, customer names, or incident details in release notes.
+
+If a private operational detail is needed to complete a release, keep it outside checked-in public documentation and translate the public-facing release note into project behavior.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -11,6 +11,8 @@ Use this checklist for public Alcove releases.
 5. Verify package metadata and public links point to `Spitfire-Cowboy/alcove`.
 6. Run `python3 scripts/check_release_packaging.py`.
 
+For a feature-batch release such as 0.4.0, start from the public [0.4.0 release plan](RELEASE_0_4_0_PLAN.md). Keep planned candidate work separate from shipped behavior until the release commit is ready.
+
 ## Release
 
 1. Create release commit and tag: `vX.Y.Z`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,12 +1,16 @@
 # Roadmap
 
-## Current release (v0.3.0)
+## Current package release (v0.3.0)
 
-Alcove ships a working three-stage pipeline: ingest, index, query. Eleven document formats. Three embedders (hash for offline determinism, sentence-transformers for local semantic search, Ollama for operator-managed local models). Two vector backends (ChromaDB, zvec). A plugin system.
+The published 0.3.0 package ships a working three-stage pipeline: ingest, index, query. It includes the local hash embedder, optional sentence-transformers semantic search, ChromaDB and zvec vector backends, a plugin system, and a web UI with upload and search.
 
-A web UI with upload and search. CI across Python 3.10, 3.11, 3.12. Docker deployment. Apache 2.0.
+The project also has CI across Python 3.10, 3.11, 3.12, Docker deployment support, and Apache 2.0 licensing.
 
 This is the foundation. Everything below builds on it.
+
+## Merged on main for next release
+
+Current `main` includes additional unreleased work intended for the next package release: Ollama embeddings, PPTX extraction, browse mode, MCP STDIO retrieval, local signing helpers, runtime deployment controls, and release packaging checks. These should be treated as unreleased until 0.4.0 is cut, tagged, and published.
 
 ## Next release planning (0.4.0)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,6 +8,12 @@ A web UI with upload and search. CI across Python 3.10, 3.11, 3.12. Docker deplo
 
 This is the foundation. Everything below builds on it.
 
+## Next release planning (0.4.0)
+
+0.4.0 is a planned feature-batch release, not a shipped release yet. The package version remains 0.3.0 until the release commit, and the final 0.4.0 scope should be decided from reviewed, merged, and verified PRs on `main`.
+
+Use [the 0.4.0 release plan](RELEASE_0_4_0_PLAN.md) to sequence pending PR review: dependency and maintenance work first, then pipeline contracts, then ingest/index changes, then query/API/UI changes, with documentation and changelog updates last. Anything not merged and verified should stay on the roadmap or become follow-up work rather than appearing as shipped 0.4.0 behavior.
+
 ## Near-term
 
 **More formats.** RTF, ODT, XLSX. PPTX is now supported by the built-in ingest pipeline. The [extractor plugin API](ARCHITECTURE.md#plugin-system) already supports additional formats; the work is writing and testing each one.

--- a/scripts/check_release_plan.py
+++ b/scripts/check_release_plan.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Validate public-safe release planning docs without creating release artifacts."""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLAN_PATH = REPO_ROOT / "docs" / "RELEASE_0_4_0_PLAN.md"
+CHANGELOG_PATH = REPO_ROOT / "CHANGELOG.md"
+ROADMAP_PATH = REPO_ROOT / "docs" / "ROADMAP.md"
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+
+PUBLIC_DOCS = [
+    CHANGELOG_PATH,
+    ROADMAP_PATH,
+    PLAN_PATH,
+    REPO_ROOT / "docs" / "RELEASE_CHECKLIST.md",
+]
+
+BANNED_MARKERS = [
+    "/Users/",
+    "alcove-private",
+    "rowan-den",
+    "Pro777",
+]
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _project_version() -> str:
+    with PYPROJECT_PATH.open("rb") as handle:
+        metadata = tomllib.load(handle)
+    return metadata["project"]["version"]
+
+
+def validate() -> list[str]:
+    errors: list[str] = []
+
+    for path in (PLAN_PATH, CHANGELOG_PATH, ROADMAP_PATH, PYPROJECT_PATH):
+        if not path.exists():
+            errors.append(f"missing required file: {path.relative_to(REPO_ROOT)}")
+
+    if errors:
+        return errors
+
+    package_version = _project_version()
+    if package_version == "1.0.0":
+        errors.append("package version must not be bumped to 1.0.0")
+    if package_version != "0.3.0":
+        errors.append(
+            "planning branch should keep package version at 0.3.0 until release"
+        )
+
+    plan = _read(PLAN_PATH)
+    changelog = _read(CHANGELOG_PATH)
+    roadmap = _read(ROADMAP_PATH)
+
+    required_plan_markers = [
+        "Status: planning only.",
+        "Target: 0.4.0 feature-batch release.",
+        "Current package version: 0.3.0 until the release commit.",
+        "## PR Review Sequence",
+        "not as 0.4.0 features",
+    ]
+    for marker in required_plan_markers:
+        if marker not in plan:
+            errors.append(f"release plan missing marker: {marker}")
+
+    if not re.search(r"^## \[0\.4\.0\] - Planned$", changelog, re.MULTILINE):
+        errors.append("CHANGELOG.md must include a planned 0.4.0 entry")
+    if "not released, not tagged" not in changelog:
+        errors.append("CHANGELOG.md must state that 0.4.0 is not released")
+    if "0.4.0" not in roadmap:
+        errors.append("docs/ROADMAP.md must reference the 0.4.0 planning target")
+
+    for path in PUBLIC_DOCS:
+        text = _read(path)
+        for marker in BANNED_MARKERS:
+            if marker in text:
+                errors.append(
+                    f"{path.relative_to(REPO_ROOT)} contains private marker {marker!r}"
+                )
+
+    return errors
+
+
+def main() -> int:
+    errors = validate()
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print("release plan checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_release_plan.py
+++ b/scripts/check_release_plan.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import re
 import sys
-import tomllib
 from pathlib import Path
 
 
@@ -35,9 +34,14 @@ def _read(path: Path) -> str:
 
 
 def _project_version() -> str:
-    with PYPROJECT_PATH.open("rb") as handle:
-        metadata = tomllib.load(handle)
-    return metadata["project"]["version"]
+    match = re.search(
+        r'^\[project\][\s\S]*?^version = "([^"]+)"$',
+        _read(PYPROJECT_PATH),
+        re.MULTILINE,
+    )
+    if not match:
+        return ""
+    return match.group(1)
 
 
 def validate() -> list[str]:

--- a/tests/test_public_docs_hygiene.py
+++ b/tests/test_public_docs_hygiene.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import subprocess
+import sys
 from pathlib import Path
 
 
@@ -18,6 +20,36 @@ def test_release_checklist_exists_and_has_core_sections() -> None:
         assert section in text
     assert ".github/workflows/release.yml" in text
     assert ".github/workflows/publish.yml" in text
+    assert "RELEASE_0_4_0_PLAN.md" in text
+
+
+def test_release_0_4_0_plan_is_planning_only() -> None:
+    plan = _read("docs/RELEASE_0_4_0_PLAN.md")
+    changelog = _read("CHANGELOG.md")
+    roadmap = _read("docs/ROADMAP.md")
+    pyproject = _read("pyproject.toml")
+
+    assert "Status: planning only." in plan
+    assert "Target: 0.4.0 feature-batch release." in plan
+    assert "## PR Review Sequence" in plan
+    assert "not as 0.4.0 features" in plan
+    assert "## [0.4.0] - Planned" in changelog
+    assert "not released, not tagged" in changelog
+    assert "Next release planning (0.4.0)" in roadmap
+    assert 'version = "0.3.0"' in pyproject
+    assert 'version = "1.0.0"' not in pyproject
+
+
+def test_release_plan_checker_passes() -> None:
+    result = subprocess.run(
+        [sys.executable, "scripts/check_release_plan.py"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "release plan checks passed" in result.stdout
 
 
 def test_canonical_public_repo_slug_in_metadata_and_docs() -> None:
@@ -50,8 +82,17 @@ def test_demo_links_use_current_pages_domain() -> None:
 
 
 def test_public_docs_avoid_private_operational_markers() -> None:
-    files = ["README.md", "docs/SECURITY.md", "docs/index.html", "docs/demo-cli.html"]
-    banned = ["alcove-private", "rowan-den", "/Users/"]
+    files = [
+        "README.md",
+        "CHANGELOG.md",
+        "docs/ROADMAP.md",
+        "docs/RELEASE_0_4_0_PLAN.md",
+        "docs/RELEASE_CHECKLIST.md",
+        "docs/SECURITY.md",
+        "docs/index.html",
+        "docs/demo-cli.html",
+    ]
+    banned = ["alcove-private", "rowan-den", "/Users/", "Pro777"]
     for rel in files:
         text = _read(rel)
         for marker in banned:


### PR DESCRIPTION
## Summary
- add a planned 0.4.0 release sequencing document without bumping package version or tagging
- add a read-only release-plan validator
- update release checklist, roadmap, changelog, and docs hygiene coverage

## Scope notes
- this is planning only; it does not mark pending draft PR behavior as shipped
- explicitly keeps 1.0.0 out of scope for this batch

## Verification
- `python3 scripts/check_release_plan.py`
- `python3 -m pytest tests/test_public_docs_hygiene.py -q`
- `git diff --check`

Draft until reviewed by John.
