### PR TITLE
Document desktop packaging status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to alcove-search.
 
 ## [Unreleased]
 
+- Document desktop packaging status and guardrails without claiming a supported app bundle.
+- Add focused checks for public-safe Briefcase metadata and local-first desktop packaging docs.
 - Add read-only browse document detail pages with stable IDs and chunk previews.
 - Add a read-only browse mode for recent indexed documents, collections, file types, authors, and years.
 - Add release packaging checks for public metadata, release workflows, and Homebrew formula safety.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The full roadmap is in [docs/ROADMAP.md](docs/ROADMAP.md). Alcove will not becom
 
 ## Documentation
 
-[Why Alcove?](WHY.md) · [Architecture](docs/ARCHITECTURE.md) · [Operations](docs/OPERATIONS.md) · [Security](docs/SECURITY.md) · [Seed Corpus](docs/SEED_CORPUS.md) · [Roadmap](docs/ROADMAP.md) · [Plugin Ideas](docs/PLUGINS.md) · [Accessibility](ACCESSIBILITY.md)
+[Why Alcove?](WHY.md) · [Architecture](docs/ARCHITECTURE.md) · [Operations](docs/OPERATIONS.md) · [Security](docs/SECURITY.md) · [Desktop Packaging](docs/DESKTOP.md) · [Seed Corpus](docs/SEED_CORPUS.md) · [Roadmap](docs/ROADMAP.md) · [Plugin Ideas](docs/PLUGINS.md) · [Accessibility](ACCESSIBILITY.md)
 
 ## License
 

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -1,0 +1,33 @@
+# Desktop Packaging
+
+Alcove does not currently ship a desktop application bundle.
+
+The repository keeps minimal Briefcase metadata in `pyproject.toml` so packaging work has a public project identity and canonical source URL. It deliberately does not define a `tool.briefcase.app.*` target yet. Until a real desktop shell exists, `briefcase build`, `briefcase run`, and platform installer generation are not supported release paths.
+
+## Current Status
+
+- Supported distribution: Python package and source checkout.
+- Supported user interfaces: CLI and local FastAPI web UI.
+- Desktop app status: packaging preparation only.
+- Local-first boundary: unchanged. Ingested documents, processed chunks, embeddings, and vector stores stay on the operator's disk.
+
+## Packaging Principles
+
+Desktop packaging must preserve the existing architecture:
+
+- The app shell may launch or supervise Alcove, but the ingest, index, and query pipeline remains the source of truth.
+- The default runtime must not add telemetry, account creation, hosted storage, or background network calls.
+- The hash embedder remains available as a zero-download mode. Sentence-transformers remains opt-in and may download its model on first use.
+- Platform packaging must not include private hostnames, deployment paths, private repository references, local user paths, signing identities, or personal data.
+
+## Before Adding a Briefcase App Target
+
+A future `tool.briefcase.app.alcove` section should not be added until these pieces exist:
+
+1. A real desktop entry point that starts a useful local experience.
+2. Explicit platform notes for macOS, Windows, and Linux.
+3. Tests that verify the desktop entry point does not change Alcove's local-first defaults.
+4. A release checklist section for app signing, notarization, installer contents, and public artifact naming.
+5. Manual verification notes for a clean machine or disposable user account.
+
+Until then, the honest state is preparation, not a half-working app bundle.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,7 +10,7 @@ This is the foundation. Everything below builds on it.
 
 ## Merged on main for next release
 
-Current `main` includes additional unreleased work intended for the next package release: Ollama embeddings, PPTX extraction, browse mode, MCP STDIO retrieval, local signing helpers, runtime deployment controls, and release packaging checks. These should be treated as unreleased until 0.4.0 is cut, tagged, and published.
+Current `main` includes additional unreleased work intended for the next package release: Ollama embeddings, PPTX extraction, browse mode, MCP STDIO retrieval, local signing helpers, runtime deployment controls, release packaging checks, and desktop packaging preparation. These should be treated as unreleased until 0.4.0 is cut, tagged, and published.
 
 ## Next release planning (0.4.0)
 
@@ -19,6 +19,8 @@ Current `main` includes additional unreleased work intended for the next package
 Use [the 0.4.0 release plan](RELEASE_0_4_0_PLAN.md) to sequence pending PR review: dependency and maintenance work first, then pipeline contracts, then ingest/index changes, then query/API/UI changes, with documentation and changelog updates last. Anything not merged and verified should stay on the roadmap or become follow-up work rather than appearing as shipped 0.4.0 behavior.
 
 ## Near-term
+
+**Desktop packaging preparation.** Keep Briefcase metadata public and minimal, document that no desktop app bundle ships yet, and add checks that prevent accidental private paths, hostnames, or release claims from entering packaging files. The first milestone is packaging readiness, not an app-shaped wrapper around an unfinished experience.
 
 **More formats.** RTF, ODT, XLSX. PPTX is now supported by the built-in ingest pipeline. The [extractor plugin API](ARCHITECTURE.md#plugin-system) already supports additional formats; the work is writing and testing each one.
 
@@ -50,7 +52,7 @@ Use [the 0.4.0 release plan](RELEASE_0_4_0_PLAN.md) to sequence pending PR revie
 
 **Federation.** Multiple Alcove instances sharing a query surface without sharing raw data. A research group, a neighborhood archive, a distributed records system: each node owns its corpus, but queries can span the constellation. [Sovereignty is preserved; reach is expanded.](../WHY.md#the-tension-is-the-product)
 
-**Desktop application.** A native app for people who should not need a terminal to search their own files. This is packaging and distribution work, not architecture work; the core stays the same.
+**Desktop application.** A native app for people who should not need a terminal to search their own files. This is packaging and distribution work, not architecture work; the core stays the same. Current status is documented in [Desktop Packaging](DESKTOP.md): Alcove has preparation docs and checks, but no supported desktop bundle yet.
 
 ## Plugin candidates
 

--- a/tests/test_desktop_packaging.py
+++ b/tests/test_desktop_packaging.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+DESKTOP_DOC = REPO_ROOT / "docs" / "DESKTOP.md"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_briefcase_metadata_is_public_and_preparatory_only() -> None:
+    text = _read(PYPROJECT)
+
+    assert '[tool.briefcase]' in text
+    assert 'bundle = "com.alcove-search"' in text
+    assert 'url = "https://github.com/Spitfire-Cowboy/alcove"' in text
+
+    app_target = re.search(r"^\[tool\.briefcase\.app\.[^\]]+\]", text, re.MULTILINE)
+    assert app_target is None, (
+        "Do not add a Briefcase app target until docs/DESKTOP.md prerequisites are met"
+    )
+
+
+def test_desktop_packaging_doc_is_honest_about_status() -> None:
+    text = _read(DESKTOP_DOC)
+
+    required = [
+        "does not currently ship a desktop application bundle",
+        "packaging preparation only",
+        "briefcase build",
+        "not supported release paths",
+        "Until then, the honest state is preparation",
+    ]
+    for phrase in required:
+        assert phrase in text
+
+
+def test_desktop_packaging_preserves_local_first_boundary() -> None:
+    text = _read(DESKTOP_DOC)
+
+    required = [
+        "stay on the operator's disk",
+        "must not add telemetry",
+        "account creation",
+        "hosted storage",
+        "background network calls",
+        "Sentence-transformers remains opt-in",
+    ]
+    for phrase in required:
+        assert phrase in text
+
+
+def test_desktop_packaging_docs_are_public_safe() -> None:
+    files = [
+        PYPROJECT,
+        DESKTOP_DOC,
+        REPO_ROOT / "docs" / "ROADMAP.md",
+        REPO_ROOT / "CHANGELOG.md",
+    ]
+    banned = [
+        "/Users/",
+        "alcove-private",
+        "rowan-den",
+        "Pro777/alcove",
+        "localhost.localdomain",
+    ]
+
+    for path in files:
+        text = _read(path)
+        for marker in banned:
+            assert marker not in text, f"Found private marker {marker!r} in {path}"

--- a/tests/test_public_docs_hygiene.py
+++ b/tests/test_public_docs_hygiene.py
@@ -91,8 +91,16 @@ def test_public_docs_avoid_private_operational_markers() -> None:
         "docs/SECURITY.md",
         "docs/index.html",
         "docs/demo-cli.html",
+        "docs/DESKTOP.md",
+        "pyproject.toml",
     ]
-    banned = ["alcove-private", "rowan-den", "/Users/", "Pro777"]
+    banned = [
+        "alcove-private",
+        "rowan-den",
+        "/Users/",
+        "Pro777",
+        "localhost.localdomain",
+    ]
     for rel in files:
         text = _read(rel)
         for marker in banned:


### PR DESCRIPTION
## Summary
- add an honest desktop packaging status doc
- clarify that Briefcase metadata is preparatory and no supported desktop app bundle ships yet
- add tests for public Briefcase metadata, no app target claims, and local-first desktop guardrails

## Verification
- `python3 -m pytest -q tests/test_desktop_packaging.py tests/test_public_docs_hygiene.py`
- `python3 -m pytest`
- `git diff --check`
- public marker scan found no private paths/hostnames/repo markers outside intentional banned-marker tests

Draft until reviewed by John.
