### PR TITLE
Prepare 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ All notable changes to alcove-search.
 
 ## [0.4.0] - 2026-05-12
 
-- Consolidate public README, architecture, operations, and roadmap docs around the published package and current unreleased main-branch scope.
-- Add a pending-feature map so draft manifest, provenance, streaming ingest, multilingual, and cross-modal work is not presented as already shipped.
+- Consolidate public README, architecture, operations, and roadmap docs around the published 0.4.0 package scope.
+- Add a pending-feature map to indicate draft manifest, provenance, streaming ingest, multilingual, and cross-modal work are not part of this release.
 - Clarify install, trust-boundary, API, collection, backup, and docs hygiene guidance.
 - Document desktop packaging status and guardrails without claiming a supported app bundle.
 - Add focused checks for public-safe Briefcase metadata and local-first desktop packaging docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,26 +4,22 @@ All notable changes to alcove-search.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-12
+
+- Consolidate public README, architecture, operations, and roadmap docs around the published package and current unreleased main-branch scope.
+- Add a pending-feature map so draft manifest, provenance, streaming ingest, multilingual, and cross-modal work is not presented as already shipped.
+- Clarify install, trust-boundary, API, collection, backup, and docs hygiene guidance.
 - Document desktop packaging status and guardrails without claiming a supported app bundle.
 - Add focused checks for public-safe Briefcase metadata and local-first desktop packaging docs.
 - Add read-only browse document detail pages with stable IDs and chunk previews.
 - Add a read-only browse mode for recent indexed documents, collections, file types, authors, and years.
 - Add release packaging checks for public metadata, release workflows, and Homebrew formula safety.
-- Add a public 0.4.0 release plan while keeping the package version at 0.3.0 until release.
+- Add public 0.4.0 release notes and bump package metadata to 0.4.0.
 - Add `EMBEDDER=ollama` for local Ollama embedding models.
 - Add built-in PPTX text extraction and pipeline dispatch.
 - Add local Ed25519 signing helpers and a standalone index signing tool for provenance checks.
 - Add a STDIO Model Context Protocol server for querying local Alcove indexes.
 - Add runtime configuration feature flags for environment and config-file controlled deployments.
-
-## [0.4.0] - Planned
-
-Planning status: not released, not tagged, and not reflected in package metadata.
-
-- Prepare a public release plan for a 0.4.0 feature-batch release.
-- Review pending feature PRs in dependency order before deciding final scope.
-- Keep release notes limited to merged, verified behavior at release time.
-- Keep the package version at 0.3.0 until the actual release commit.
 
 ## [0.3.0] - 2026-03-07
 

--- a/README.md
+++ b/README.md
@@ -8,89 +8,102 @@
   <a href="https://github.com/Spitfire-Cowboy/alcove/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License"></a>
 </p>
 
-**Index your world. Share it with the universe.**
+**Local-first document retrieval. Your data never leaves your disk.**
 
 ---
 
-Every AI tool needs your data to be useful. The default answer is: upload it, hand it over, hope for the best. Alcove is the other answer.
+Alcove is search infrastructure for documents you keep on your own machine. It ingests a local directory, extracts text, chunks it, writes a local index, and returns matching chunks through a CLI or local web/API server.
 
-Alcove is a search engine that runs on your machine, indexes your files, and never sends a byte anywhere. Your documents stay on your disk. The search index stays on your disk. When you search, or when an AI tool needs to look something up, Alcove answers from what you have locally. No cloud. No account. No trust required.
+It is retrieval, not generation. Alcove does not summarize, answer questions, host models, or invent text. Search results are excerpts from the indexed corpus.
 
 **[See it in 30 seconds](https://spitfire-cowboy.github.io/alcove/demo.html)** · [Why Alcove?](WHY.md)
 
+## What ships today
+
+Alcove v0.4.0 ships a working local pipeline:
+
+- Recursive ingest for PDF, EPUB, HTML, Markdown, CSV, JSON, JSONL, DOCX, PPTX, RST, TSV, and plain text.
+- Local indexing with ChromaDB by default, with zvec available as an optional backend.
+- A deterministic hash embedder by default, plus opt-in sentence-transformers and Ollama embedders for real semantic similarity.
+- CLI search and a FastAPI web service with search, upload, health, collection-list, and browse endpoints.
+- Semantic, keyword (BM25), and hybrid search modes.
+- Named collection metadata and collection filtering.
+- STDIO MCP retrieval tools for local index search and collection listing.
+- Local signing helpers and index signing tooling for provenance checks.
+- Python entry-point plugins for extractors, embedders, and vector backends.
+
+The roadmap includes richer manifests, provenance workflows, streaming ingest, and more plugin categories. Those are not documented here as shipped behavior; see [Roadmap](docs/ROADMAP.md) for the pending-feature map.
+
 ## How it works
 
-Three stages. Each is independent, each reads from disk and writes to disk, each can be re-run without touching the others.
+Three stages. Each stage reads from local disk and writes to local disk, so it can be re-run independently.
 
+```text
+data/raw/* -> data/processed/chunks.jsonl -> vector store -> query responses
 ```
-data/raw/*  →  chunks.jsonl  →  vector store  →  search results
-```
 
-**Ingest** discovers files recursively and extracts text with format-specific extractors. PDF, EPUB, HTML, Markdown, CSV, JSON, JSONL, DOCX, RST, TSV, and plain text all work out of the box.
+**Ingest** discovers files recursively and extracts text with format-specific extractors.
 
-**Index** embeds the chunks and writes them to a local vector store. ChromaDB is the default backend; zvec is available where a lighter footprint matters.
+**Index** embeds chunks and writes vectors plus metadata to a local vector store.
 
-**Query** retrieves results through the CLI or a built-in web interface with file upload. Three search modes: semantic (vector similarity), keyword (BM25), and hybrid. Results can be scoped to named collections.
+**Query** retrieves matching chunks through the CLI or local API/web UI.
 
-Fixed pipeline, variable corpus. Custom extractors, embedders, and vector backends plug in via Python entry points. See [Architecture](docs/ARCHITECTURE.md) for the full plugin API and [Plugin Ideas](docs/PLUGINS.md) for domain-specific use cases.
+See [Architecture](docs/ARCHITECTURE.md) for module boundaries and extension points.
 
 ## Quick start
 
 ```bash
 pip install alcove-search[semantic]
+alcove seed-demo
+alcove serve
 ```
 
-This pulls in sentence-transformers for real vector similarity (~80 MB model download on first use). The base package without `[semantic]` uses the hash embedder: useful for development and CI, but not for meaningful search.
+Open `http://localhost:8000`.
+
+The `[semantic]` extra installs sentence-transformers. The first semantic run downloads `all-MiniLM-L6-v2` once, then runs locally. For zero-download installs:
+
+```bash
+pip install alcove-search
+```
+
+The base package uses the hash embedder. It is deterministic, offline, and useful for smoke tests or operators who do not want ML in the pipeline. It is not a semantic search model.
 
 <details>
-<summary>All install extras</summary>
+<summary>Install extras</summary>
 
 | Extra | Install command | What it adds |
 |-------|----------------|--------------|
 | Semantic search | `pip install alcove-search[semantic]` | Real vector similarity via sentence-transformers |
-| EPUB support | `pip install alcove-search[epub]` | `.epub` file ingestion |
-| DOCX support | `pip install alcove-search[docx]` | `.docx` file ingestion |
-| Everything | `pip install alcove-search[semantic,epub,docx]` | All of the above |
+| EPUB support | `pip install alcove-search[epub]` | `.epub` ingestion |
+| DOCX support | `pip install alcove-search[docx]` | `.docx` ingestion |
+| zvec backend | `pip install alcove-search[zvec]` | Optional zvec vector store |
+| PPTX support | `pip install alcove-search[pptx]` | `.pptx` ingestion |
+| Everything | `pip install alcove-search[semantic,epub,docx,pptx,zvec]` | All optional runtime features |
 
 </details>
 
-```bash
-alcove seed-demo          # download sample corpus + build index
-alcove serve              # open http://localhost:8000
-```
-
 <table><tr>
-<td><a href="docs/assets/web-ui-dark.png"><img src="docs/assets/web-ui-dark.png" alt="Alcove UI — dark theme" width="420"></a></td>
-<td><a href="docs/assets/web-ui-light.png"><img src="docs/assets/web-ui-light.png" alt="Alcove UI — light theme" width="420"></a></td>
+<td><a href="docs/assets/web-ui-dark.png"><img src="docs/assets/web-ui-dark.png" alt="Alcove UI, dark theme" width="420"></a></td>
+<td><a href="docs/assets/web-ui-light.png"><img src="docs/assets/web-ui-light.png" alt="Alcove UI, light theme" width="420"></a></td>
 </tr></table>
-
-## The trust dial
-
-You choose your comfort level with ML. Both modes run the same pipeline, produce the same output format, and respect the same boundary: nothing leaves the machine.
-
-**Hash embedder (default):** Deterministic SHA-256. No ML model. No network activity. Every output is a pure function of the input. This is for operators who do not want machine learning anywhere near their corpus.
-
-**Sentence-transformers (opt-in):** Real vector similarity via a local neural model, downloaded once. Still fully local. Still no cloud. This is retrieval, not generation: it finds documents that are semantically close to your query. It does not write, invent, or editorialize.
 
 ## Trust model
 
-Local disk only. No outbound network calls. No telemetry. No account to create. We disabled ChromaDB's upstream telemetry too.
+Local disk only for normal ingest, index, query, and serve operations. No telemetry. No account creation. ChromaDB's upstream telemetry is disabled.
 
-**We do not want your data.**
+Network use is explicit: `alcove seed-demo` fetches the public sample corpus, and sentence-transformers downloads its model on first use. After that, embedding runs locally.
 
-This is not a feature. It is a structural constraint. The architecture assumes you own your hardware, you control your storage, and you decide what enters the index. There is no flag to turn this off because there is nothing to turn off. The boundary is the architecture.
+Alcove does not require authentication. The local API is open to anyone who can reach the port, so keep it bound to `127.0.0.1` unless you put authentication in front of it. See [Operations](docs/OPERATIONS.md) and [Security](docs/SECURITY.md).
 
-Alcove stores everything on your disk because that is where your data already lives. Moving it somewhere else to search it was always the strange decision.
+## Common commands
 
-## Where it is going
-
-v0.3.0 is a working search platform. That is the "index your world" part.
-
-The "share it with the universe" part comes next: a retrieval interface that lets external tools query your index, on your terms. Your files stay local. Your index stays yours. But if you choose to open a door, AI gets real answers from your actual documents. No hallucinations, because there is no generation. Just lookup.
-
-Beyond that: streaming ingest, browsable corpus navigation, cross-modal indexing, a relevance layer that treats memory more like memory and less like a distance calculation, and federated indexes that let separate Alcove instances share a query surface without sharing raw data.
-
-The full roadmap is in [docs/ROADMAP.md](docs/ROADMAP.md). Alcove will not become a SaaS product. The architecture assumes the operator owns the hardware.
+```bash
+alcove ingest /path/to/files
+alcove search "phrase to find" --mode hybrid --k 5
+alcove collections
+alcove status
+alcove serve --host 127.0.0.1 --port 8000
+```
 
 ## Documentation
 
@@ -99,7 +112,3 @@ The full roadmap is in [docs/ROADMAP.md](docs/ROADMAP.md). Alcove will not becom
 ## License
 
 [Apache 2.0](LICENSE)
-
----
-
-*The word [alcove](https://en.wikipedia.org/wiki/Alcove_(architecture)) comes from Arabic* القبة *(al-qubbah) — "the vault." An enclosed, protected space for things that matter.*

--- a/alcove/__init__.py
+++ b/alcove/__init__.py
@@ -1,3 +1,3 @@
 """Alcove — local-first document retrieval."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,30 +1,34 @@
 # Architecture
 
-The [README](../README.md) describes three stages: ingest, index, query. They are independent modules that operate over local files only. Each stage reads from disk, writes to disk, and knows nothing about the others. You can re-run any stage without touching the rest.
+Alcove is a local-first retrieval pipeline. It has three independent stages: ingest, index, and query. Each stage reads from local disk, writes to local disk, and can be run again without changing the others.
 
+```text
+data/raw/* -> data/processed/chunks.jsonl -> vector store -> query responses
 ```
-data/raw/*  →  data/processed/chunks.jsonl  →  vector store  →  query responses
-```
+
+Alcove does not generate text. It returns chunks that already exist in the indexed corpus.
+
+## Shipped pipeline
+
+| Stage | Module | Input | Output |
+|-------|--------|-------|--------|
+| Ingest | `alcove/ingest` | Files under a local directory | `data/processed/chunks.jsonl` |
+| Index | `alcove/index` | Chunk JSONL | Local vector store |
+| Query | `alcove/query` | Query text and optional filters | Matching chunks plus metadata |
+
+The CLI in `alcove/cli.py` wires these modules into commands such as `alcove ingest`, `alcove search`, `alcove collections`, `alcove status`, and `alcove serve`.
 
 ## Ingest
 
-`alcove/ingest` discovers files in `data/raw/**` and extracts text using format-specific extractors, then chunks the output into JSONL.
+Ingest discovers files recursively and extracts plain text using extension-specific extractors. The output is newline-delimited JSON, so the indexer can be rerun without re-reading the source files.
 
-## Index
-
-`alcove/index` reads chunks and writes embeddings plus metadata to a local vector store. ChromaDB is the default. zvec is the alternative.
-
-## Query
-
-`alcove/query` retrieves results via the CLI or a built-in FastAPI web service with file upload.
-
-## Supported formats
+Supported formats:
 
 | Format | Extension | Dependency |
 |--------|-----------|------------|
 | Plain text | `.txt` | none |
 | PDF | `.pdf` | pypdf |
-| EPUB | `.epub` | ebooklib (optional) |
+| EPUB | `.epub` | ebooklib (optional extra) |
 | HTML | `.html`, `.htm` | beautifulsoup4 |
 | Markdown | `.md` | none |
 | reStructuredText | `.rst` | none |
@@ -32,26 +36,43 @@ data/raw/*  →  data/processed/chunks.jsonl  →  vector store  →  query resp
 | TSV | `.tsv` | none |
 | JSON | `.json` | none |
 | JSONL | `.jsonl` | none |
-| DOCX | `.docx` | python-docx (optional) |
+| DOCX | `.docx` | python-docx (optional extra) |
+| PPTX | `.pptx` | python-pptx (optional extra) |
 
-## Embedders
+## Index
+
+Index reads chunks, embeds their text, and writes vectors plus metadata to a local backend. Metadata includes source and collection fields used by result rendering and collection filtering.
+
+### Embedders
 
 | Name | Env value | Description |
 |------|-----------|-------------|
-| Hash (default) | `EMBEDDER=hash` | Deterministic SHA-256 hash. Offline, zero download. Useful for smoke tests and CI. |
-| Sentence Transformers | `EMBEDDER=sentence-transformers` | Real semantic search via `all-MiniLM-L6-v2` (~80 MB model, downloaded on first use) |
-| Ollama | `EMBEDDER=ollama` | Real semantic search via an operator-managed local Ollama server |
+| Hash (default) | `EMBEDDER=hash` | Deterministic SHA-256 vectors. Offline, zero download, useful for smoke tests and non-ML operation. |
+| Sentence Transformers | `EMBEDDER=sentence-transformers` | Semantic embeddings via `all-MiniLM-L6-v2`; downloads the model on first use, then runs locally. |
+| Ollama | `EMBEDDER=ollama` | Semantic embeddings via an operator-managed Ollama server; defaults to local loopback. |
 
-Set the embedder with the `EMBEDDER` environment variable. See [OPERATIONS.md](OPERATIONS.md#environment-variables) for how to configure it. Custom embedders can be installed as plugins.
-
-## Vector backends
+### Vector backends
 
 | Name | Env value | Dependency |
 |------|-----------|------------|
-| ChromaDB (default) | `VECTOR_BACKEND=chromadb` | chromadb (included) |
-| zvec | `VECTOR_BACKEND=zvec` | zvec (optional) |
+| ChromaDB (default) | `VECTOR_BACKEND=chromadb` | chromadb |
+| zvec | `VECTOR_BACKEND=zvec` | zvec optional extra |
 
-Set the backend with the `VECTOR_BACKEND` environment variable. See [OPERATIONS.md](OPERATIONS.md#environment-variables) for how to configure it.
+ChromaDB telemetry is disabled. The storage paths and collection naming rules are documented in [Operations](OPERATIONS.md#environment-variables).
+
+## Query
+
+Query is available through the CLI and through the FastAPI app started by `alcove serve`.
+
+Search modes:
+
+| Mode | Behavior |
+|------|----------|
+| `semantic` | Embed the query and run vector similarity against the local backend. |
+| `keyword` | Run BM25 over `data/processed/chunks.jsonl`. |
+| `hybrid` | Merge semantic and keyword results. |
+
+The API accepts collection filters. The web UI displays collection chips when more than one collection exists.
 
 ## Browse mode
 
@@ -70,33 +91,43 @@ available.
 
 ## Plugin system
 
-Custom extractors, embedders, and vector backends plug in via [Python entry points](https://packaging.python.org/en/latest/specifications/entry-points/). Three extension groups:
+Plugins use Python entry points. Three extension groups are shipped:
 
 | Group | Purpose | Example entry point |
 |-------|---------|---------------------|
 | `alcove.extractors` | Add file format support | `rtf = my_plugin:extract_rtf` |
-| `alcove.backends` | Add vector store backends | `pinecone = my_plugin:PineconeBackend` |
-| `alcove.embedders` | Add embedding models | `openai = my_plugin:OpenAIEmbedder` |
+| `alcove.backends` | Add vector store backends | `sqlite_vec = my_plugin:SQLiteVecBackend` |
+| `alcove.embedders` | Add embedding models | `local_model = my_plugin:LocalEmbedder` |
 
-To create a plugin, add an `[project.entry-points]` section in your package's `pyproject.toml`:
+To create a plugin, add an entry-point section to your package:
 
 ```toml
 [project.entry-points."alcove.extractors"]
 rtf = "my_plugin:extract_rtf"
 ```
 
-Plugins are merged with built-ins at startup. When a plugin and a built-in share the same name, the plugin wins. See [ROADMAP.md](ROADMAP.md#mid-term) for planned plugin API expansion and [PLUGINS.md](PLUGINS.md) for domain-specific plugin ideas and recipes.
+Plugins are discovered at startup and merged with built-ins. If a plugin and a built-in use the same name, the plugin wins.
+
+Plugins can change the trust boundary. A cloud embedder or hosted backend can send data off-machine if an operator installs and selects it. That is outside the default Alcove boundary and must be documented by the plugin.
 
 ## Boundary
 
-The operator owns the host and the storage. Alcove makes no outbound network calls by default; the one exception is `sentence-transformers`, which downloads a model on first use and then runs locally. `EMBEDDER=ollama` sends chunk text only to the Ollama base URL the operator configures, defaulting to the local loopback interface. Telemetry is disabled, including ChromaDB's upstream telemetry. See [SECURITY.md](SECURITY.md#security-model) for the full security model.
+The operator owns the host and the storage. Normal ingest, index, query, and serve operations use local disk. Explicit network use is limited to commands or options the operator selects, such as fetching the public seed corpus, downloading the optional sentence-transformers model on first use, or pointing `EMBEDDER=ollama` at an operator-managed Ollama endpoint. Ollama defaults to the local loopback interface. Telemetry is disabled, including ChromaDB's upstream telemetry.
 
-This boundary is structural, not configurable. There is no flag to turn it off.
+Alcove does not include authentication or authorization. Keep the server bound to localhost unless a reverse proxy, network policy, or OS-level access control protects it.
+
+See [Security](SECURITY.md) for the full security model.
+
+## Release boundary
+
+The published 0.4.0 package includes the STDIO MCP server, browse mode, Ollama embeddings, PPTX extraction, local signing helpers, runtime deployment controls, and desktop packaging preparation.
+
+Manifest-based registry discovery, richer provenance workflows, streaming ingest, multilingual model-selection UX, and cross-modal indexing remain design or roadmap work unless a shipped CLI command, API endpoint, or module implements them. The status map lives in [Roadmap](ROADMAP.md#pending-feature-map).
 
 ## Tradeoffs
 
-The hash embedder ships as the default because it requires zero downloads and works offline. The cost is that it produces deterministic but non-semantic vectors; swap to `sentence-transformers` for real search quality.
+The hash embedder ships as the default because it requires zero downloads and works offline. The cost is that it produces deterministic but non-semantic vectors; use `sentence-transformers` for real semantic search quality.
 
-ChromaDB is the default backend for broad compatibility and ecosystem support. Use zvec for deployments where a lighter footprint matters more than ChromaDB's feature set.
+ChromaDB is the default backend for compatibility and ecosystem support. zvec is available for operators who want a lighter optional backend.
 
-The implementation is deliberately thin. The goal at v0.3.0 is a correct, working pipeline, not an optimized one. Performance work comes after the architecture is proven.
+The implementation is deliberately thin. The v0.4.0 goal is a correct local retrieval pipeline with clear extension points, not a managed platform.

--- a/docs/MANIFEST.md
+++ b/docs/MANIFEST.md
@@ -1,6 +1,12 @@
 # Manifest Format & Registry Discovery
 
-Alcove uses an optional `alcove.json` file to declare which plugin and index registries the runtime should consult, and which plugins and indexes are configured for this instance.
+Status: draft design. The shipped v0.4.0 runtime discovers installed plugins through
+Python entry points. It does not yet read `alcove.json`, consult remote registries, or
+discover network indexes from a registry.
+
+This document describes a proposed `alcove.json` file that could declare which plugin
+and index registries a future runtime should consult, and which plugins and indexes are
+configured for an instance.
 
 This document defines the manifest schema, the registry JSON format, and the design rationale.
 
@@ -8,18 +14,20 @@ This document defines the manifest schema, the registry JSON format, and the des
 
 ## Overview
 
-Two primitives:
+Proposed primitives:
 
 - **Plugin registry** — a JSON list of installable Alcove plugins (extractors, backends, embedders). Served at a URL; default is `https://plugins.alcove.software/registry.json`.
 - **Index registry** — a JSON list of published Alcove search indexes (corpora accessible over a network). Served at a URL; default is `https://search.alcove.software/registry.json`.
 
-Pointing your runtime at a community fork is a single URL change in `alcove.json`.
+If this design ships, pointing a runtime at a community fork would be a single URL
+change in `alcove.json`.
 
 ---
 
 ## alcove.json schema
 
-Place `alcove.json` at the root of your Alcove deployment directory (next to `pyproject.toml` or `docker-compose.yml`).
+In the proposed design, `alcove.json` would live at the root of an Alcove deployment
+directory.
 
 ```json
 {

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,26 +1,28 @@
 # Operations
 
+This guide covers the shipped local runtime: install, ingest, index, search, serve, back up, and test. It does not cover planned MCP, registry, or hosted-index workflows.
+
 ## First run
 
 ```bash
-pip install alcove-search
-alcove seed-demo          # download sample corpus + build index
-alcove serve              # open http://localhost:8000
+pip install alcove-search[semantic]
+alcove seed-demo
+alcove serve
 ```
 
-For how the pipeline works, see [Architecture](ARCHITECTURE.md).
+Open `http://localhost:8000`.
 
-## Enabling semantic search
+`seed-demo` fetches the public sample corpus, ingests it, and builds a local index. See [Seed Corpus](SEED_CORPUS.md) for what it includes.
 
-By default, Alcove uses a deterministic hash embedder (offline, no external models). For semantic search:
+For the zero-download base install:
 
 ```bash
-pip install alcove-search[semantic]
-EMBEDDER=sentence-transformers alcove seed-demo
-EMBEDDER=sentence-transformers alcove serve
+pip install alcove-search
+alcove seed-demo
+alcove serve
 ```
 
-This downloads `all-MiniLM-L6-v2` (~80 MB) on first use. See [Seed Corpus](SEED_CORPUS.md) for what `seed-demo` includes. The model is cached locally; subsequent runs are offline.
+The base install uses the hash embedder. It is deterministic and offline, but it is not a semantic model.
 
 ## Local Ollama embeddings
 
@@ -38,25 +40,61 @@ By default Alcove connects to `http://127.0.0.1:11434`. Set `OLLAMA_BASE_URL` to
 
 ```bash
 alcove ingest /path/to/your/files
+alcove search "phrase to find" --mode hybrid --k 5
 alcove serve
 ```
 
-Files can also be uploaded via the web UI at `http://localhost:8000`.
+Files can also be uploaded through the local web UI.
+
+## Search modes
+
+```bash
+alcove search "local search" --mode semantic
+alcove search "exact phrase" --mode keyword
+alcove search "mix both" --mode hybrid
+```
+
+| Mode | Use when |
+|------|----------|
+| `semantic` | You installed `[semantic]` and want meaning-based retrieval. |
+| `keyword` | Exact terms, names, identifiers, or hash-only installs matter more. |
+| `hybrid` | You want semantic retrieval with keyword backup. |
+
+## Enabling semantic search
+
+```bash
+pip install alcove-search[semantic]
+EMBEDDER=sentence-transformers alcove ingest /path/to/files
+EMBEDDER=sentence-transformers alcove serve
+```
+
+The first run downloads `all-MiniLM-L6-v2`. The model is cached locally; later runs do not require network access.
 
 ## Web UI and API
 
 ```bash
-alcove serve
+alcove serve --host 127.0.0.1 --port 8000
 ```
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
 | `/` | GET | Web UI: search and file upload |
-| `/query` | POST | `{ "query": "...", "k": 3 }` |
+| `/query` | POST | Search JSON: `{ "query": "...", "k": 3, "mode": "hybrid" }` |
 | `/ingest` | POST | File upload (multipart) |
+| `/collections` | GET | Collection names and document counts |
 | `/health` | GET | Readiness check |
 
-Bind to a non-localhost address only after reviewing [Security: Operator Responsibilities](SECURITY.md#operator-responsibilities).
+Bind to a non-localhost address only after reviewing [Security: Operator Responsibilities](SECURITY.md#operator-responsibilities). Alcove has no built-in authentication.
+
+## Collections
+
+Collections are metadata labels used for filtering. Uploaded files and index runs default to `default` unless a caller supplies a collection.
+
+```bash
+alcove collections
+```
+
+For ChromaDB, `CHROMA_COLLECTION=*` or `ALCOVE_MULTI_COLLECTION=1` enables fan-out across named ChromaDB collections in the same local store. Demo multi-root mode is controlled by `ALCOVE_DEMO_ROOT` and is read-only.
 
 ## Environment variables
 
@@ -69,10 +107,14 @@ Bind to a non-localhost address only after reviewing [Security: Operator Respons
 | `OLLAMA_DIM` | `768` | Ollama embedding dimension for backends that need it at initialization |
 | `VECTOR_BACKEND` | `chromadb` | Vector store (`chromadb` or `zvec`) |
 | `CHROMA_PATH` | `./data/chroma` | ChromaDB persistence directory |
-| `CHROMA_COLLECTION` | `alcove_docs` | Collection name |
+| `CHROMA_COLLECTION` | `alcove_docs` | ChromaDB collection name; `*` enables multi-collection fan-out |
+| `ZVEC_PATH` | `./data/zvec` | zvec persistence directory |
 | `CHUNK_SIZE` | `1000` | Characters per chunk |
 | `CHUNK_OVERLAP` | `150` | Overlap between chunks |
-| `RAW_DIR` | `data/raw` | Input directory for ingestion |
+| `RAW_DIR` | `data/raw` | Default input directory for ingestion |
+| `ALCOVE_MULTI_COLLECTION` | unset | Set to `1`, `true`, or `yes` to query all ChromaDB collections |
+| `ALCOVE_ROOT_PATH` | unset | URL prefix when served behind a reverse proxy |
+| `ALCOVE_DEMO_READONLY` | unset | Disable web upload ingest in demo/read-only mode |
 
 ## Docker
 
@@ -80,15 +122,28 @@ Bind to a non-localhost address only after reviewing [Security: Operator Respons
 docker compose up -d --build
 ```
 
-Port 8000 is exposed; the `/health` endpoint signals readiness.
+Port 8000 is exposed. Use `/health` for readiness checks.
 
-## Backup
+## Backup and rebuild
 
-Back up `data/raw`, `data/processed`, and `data/chroma` (or `data/zvec` if using the zvec backend). These directories contain everything Alcove needs to reconstruct the index.
+Back up:
+
+- `data/raw`
+- `data/processed`
+- `data/chroma` for ChromaDB
+- `data/zvec` for zvec
+
+The raw files and processed chunks are enough to rebuild the vector store. Keeping the vector store avoids re-embedding.
 
 ## Running tests
 
 ```bash
-pip install alcove-search[dev]
+pip install -e ".[dev]"
 pytest
+```
+
+Docs hygiene checks live in `tests/test_public_docs_hygiene.py`:
+
+```bash
+pytest tests/test_public_docs_hygiene.py
 ```

--- a/docs/PROVENANCE_LAYER.md
+++ b/docs/PROVENANCE_LAYER.md
@@ -1,5 +1,9 @@
 # Provenance Layer
 
+Status: draft design. Alcove stores source and collection metadata on chunks today, but
+manifest-driven provenance and compliance workflows are roadmap work, not a shipped
+runtime contract.
+
 Alcove is a view layer, not a copy layer. The design principle: store where data came from
 alongside what it says. Every chunk in the vector index should be traceable back to its
 source document, and every source document should be traceable to its origin.
@@ -23,7 +27,8 @@ compliance applications, known provenance is a hard requirement.
 ## How Alcove represents provenance
 
 Every chunk stored in the vector index carries a `metadata` dict alongside its text
-and embedding vector. The built-in fields that support provenance:
+and embedding vector. The shipped fields that support provenance are `source` and
+`collection`; the other fields below are planned or custom-ingest fields.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -32,16 +37,15 @@ and embedding vector. The built-in fields that support provenance:
 | `chunk_index` | int | Position of this chunk within the source document |
 | `ingest_date` | string (ISO 8601) | Date the chunk was written to the index |
 
-These fields are written by the ingest pipeline automatically when a file is processed.
-Additional fields (e.g. `title`, `author`, `license`, `url`) can be added by the
-extractor or by a custom ingest script.
+Richer fields such as `title`, `author`, `license`, `url`, and `ingest_date` depend on
+extractor support or custom ingest code.
 
 ---
 
 ## Manifest-based provenance
 
-The `alcove.schema.json` manifest documents each collection at the collection level. An
-entry in the manifest looks like:
+Manifest-based provenance is planned work. A future manifest could document each
+collection at the collection level. An entry might look like:
 
 ```json
 {
@@ -55,8 +59,8 @@ entry in the manifest looks like:
 }
 ```
 
-The manifest lives at `docs/alcove.schema.json` and is updated after each ingest run.
-It is the authoritative record of what is in the index and where it came from.
+The checked-in schema is a design artifact. The shipped v0.4.0 runtime does not update a
+manifest after each ingest run.
 
 ---
 
@@ -93,9 +97,8 @@ collection.upsert(
 
 ## Provenance in search results
 
-The Alcove query API returns the full metadata dict with each result. The web UI
-renders `source` and `url` as links when present. A result card without a source URL
-displays the file path as plain text.
+The Alcove query API returns metadata with results. The shipped web UI displays source
+and collection information; richer provenance rendering is planned work.
 
 Custom result rendering can add provenance display by overriding the `result_card`
 block in `alcove/web/templates/results.html`.
@@ -121,4 +124,4 @@ displaying the `author` and `source_url` in the UI satisfies the typical require
 
 - [ARCHITECTURE.md](ARCHITECTURE.md) — ingest/index pipeline overview
 - [MANIFEST.md](MANIFEST.md) — corpus manifest format and update instructions
-- [docs/alcove.schema.json](alcove.schema.json) — live manifest
+- [docs/alcove.schema.json](alcove.schema.json) — draft schema artifact

--- a/docs/RELEASE_0_4_0_PLAN.md
+++ b/docs/RELEASE_0_4_0_PLAN.md
@@ -1,65 +1,57 @@
-# Alcove 0.4.0 Release Plan
+# Alcove 0.4.0 Release Notes
 
-Status: planning only. This document does not ship features, merge feature PRs, bump package metadata, create a tag, or publish artifacts.
+Status: release-prep complete. This document records the public 0.4.0 package scope; tagging and publishing still happen after the release PR is merged.
 
-Target: 0.4.0 feature-batch release.
+Target tag: `v0.4.0`.
 
-Current package version: 0.3.0 until the release commit.
+Current package version: 0.4.0.
 
-## Scope Decision
+## Release Scope
 
-0.4.0 should be decided as a reviewed feature batch, not as a rolling collection of branch state. A feature belongs in 0.4.0 only after its PR has been reviewed, merged, tested on `main`, and documented as shipped behavior.
+0.4.0 is a feature-batch release made from reviewed and merged public work on `main`.
 
-Candidate areas to evaluate:
+Included behavior:
 
-- Retrieval surface improvements that preserve Alcove's retrieval-only contract.
-- Ingest and extractor improvements that keep data local by default.
-- Plugin-system improvements with clear entry-point compatibility notes.
-- Web or CLI usability improvements that are covered by focused tests.
-- Documentation updates that describe shipped behavior without promising unmerged work.
+- Browse mode and read-only document drill-down previews.
+- STDIO MCP retrieval tools for local search and collection listing.
+- Ollama embeddings through `EMBEDDER=ollama`.
+- PPTX text extraction.
+- Local Ed25519 signing helpers and index signing tooling.
+- Runtime deployment controls.
+- Release packaging checks for public metadata, release workflows, and Homebrew formula safety.
+- Desktop packaging preparation docs and guardrails; no desktop app bundle ships yet.
+- Public documentation cleanup that separates released behavior from draft designs.
 
-Explicitly out of scope for this planning branch:
+Deferred or still exploratory:
 
-- Version bump to 0.4.0 or 1.0.0.
-- Release tag creation.
-- Publishing to PyPI or package registries.
-- Private deployment notes, internal hostnames, private repository names, or operator-specific paths.
-
-## PR Review Sequence
-
-Use this sequence before cutting the release:
-
-1. Review dependency and maintenance PRs first so feature branches are evaluated against current dependencies.
-2. Review data-model, manifest, or plugin contract PRs before UI or documentation PRs that depend on those contracts.
-3. Review ingest and indexing changes before query/API changes that expose their output.
-4. Review user-facing CLI, API, and web changes after the underlying pipeline behavior is stable.
-5. Review documentation and changelog updates last, using only merged and verified behavior.
-
-Each accepted PR should leave behind enough evidence for release notes: tests run, public docs touched, and any compatibility notes. Deferred PRs should be listed as deferred follow-up work, not as 0.4.0 features.
+- Manifest and registry discovery.
+- Rich provenance manifests and compliance workflows.
+- Streaming ingest.
+- Cross-modal indexing.
+- Multilingual model-selection CLI flags and automatic multilingual-E5 prefix handling.
+- Federation.
 
 ## Release Checklist
 
-Before release scope is approved:
+Before tagging:
 
-- [ ] Confirm every candidate feature PR is merged or explicitly deferred.
 - [ ] Confirm `main` passes CI for supported Python versions.
 - [ ] Run focused local tests for changed surfaces.
-- [ ] Confirm package metadata still points to the public project URLs.
+- [ ] Confirm package metadata points to the public project URLs.
 - [ ] Confirm no release docs include private hostnames, private repository references, personal filesystem paths, or PII.
-- [ ] Rewrite this plan's candidate language into final release notes for only merged behavior.
+- [ ] Confirm `pyproject.toml`, `alcove/__init__.py`, `CHANGELOG.md`, and `docs/ROADMAP.md` all agree on 0.4.0.
 
 At release time:
 
-- [ ] Bump package metadata from 0.3.0 to 0.4.0 in the release commit.
-- [ ] Move the 0.4.0 changelog entry from planned scope to dated shipped scope.
+- [ ] Merge the release PR.
 - [ ] Tag `v0.4.0` only after tests and release notes are final.
+- [ ] Push the tag to trigger GitHub Release and PyPI publish workflows.
 - [ ] Verify the published artifact and public release notes.
 
 After release:
 
-- [ ] Update `docs/ROADMAP.md` so 0.4.0 is described as current shipped behavior.
-- [ ] Open follow-up issues for deferred PRs and incomplete roadmap items.
-- [ ] Remove or archive this planning checklist if it no longer reflects the public release state.
+- [ ] Sanity-check install from PyPI.
+- [ ] Open follow-up issues for deferred roadmap items.
 
 ## Public-Safety Notes
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -11,7 +11,7 @@ Use this checklist for public Alcove releases.
 5. Verify package metadata and public links point to `Spitfire-Cowboy/alcove`.
 6. Run `python3 scripts/check_release_packaging.py`.
 
-For a feature-batch release such as 0.4.0, start from the public [0.4.0 release plan](RELEASE_0_4_0_PLAN.md). Keep planned candidate work separate from shipped behavior until the release commit is ready.
+For a feature-batch release such as 0.4.0, start from the public [0.4.0 release notes](RELEASE_0_4_0_PLAN.md). Keep candidate work separate from shipped behavior until the release commit is ready.
 
 ## Release
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,113 +1,108 @@
 # Roadmap
 
-## Current package release (v0.3.0)
+This roadmap separates the published package from planned design work. Public docs should not describe roadmap items as available in a package release until they are tagged and published.
 
-The published 0.3.0 package ships a working three-stage pipeline: ingest, index, query. It includes the local hash embedder, optional sentence-transformers semantic search, ChromaDB and zvec vector backends, a plugin system, and a web UI with upload and search.
+## Current package release (v0.4.0)
 
-The project also has CI across Python 3.10, 3.11, 3.12, Docker deployment support, and Apache 2.0 licensing.
+The published 0.4.0 package ships a working local retrieval pipeline:
 
-This is the foundation. Everything below builds on it.
+- Ingest, index, and query stages over local disk.
+- Twelve document formats: PDF, EPUB, HTML, Markdown, CSV, JSON, JSONL, DOCX, PPTX, RST, TSV, and plain text.
+- Hash, sentence-transformers, and Ollama embedders.
+- ChromaDB and zvec vector backends.
+- CLI search, status, collection listing, plugin listing, and seed-demo commands.
+- FastAPI web UI/API with search, upload ingest, health, collection, and browse endpoints.
+- Semantic, keyword, and hybrid search modes.
+- Named collection metadata and collection filtering.
+- STDIO MCP retrieval tools for local search and collection listing.
+- Local signing helpers and index signing tooling.
+- Runtime deployment controls.
+- Release packaging checks.
+- Desktop packaging preparation docs and guardrails; no supported desktop bundle ships yet.
+- Python entry-point plugins for extractors, embedders, and vector backends.
+- Docker runtime, CI, accessibility improvements, and Apache 2.0 licensing.
 
-## Merged on main for next release
+See [the 0.4.0 release notes](RELEASE_0_4_0_PLAN.md) for scope details and release verification.
 
-Current `main` includes additional unreleased work intended for the next package release: Ollama embeddings, PPTX extraction, browse mode, MCP STDIO retrieval, local signing helpers, runtime deployment controls, release packaging checks, and desktop packaging preparation. These should be treated as unreleased until 0.4.0 is cut, tagged, and published.
+## Pending feature map
 
-## Next release planning (0.4.0)
+These buckets track design and future work without tying public docs to private branch names, hostnames, or PR numbers.
 
-0.4.0 is a planned feature-batch release, not a shipped release yet. The package version remains 0.3.0 until the release commit, and the final 0.4.0 scope should be decided from reviewed, merged, and verified PRs on `main`.
-
-Use [the 0.4.0 release plan](RELEASE_0_4_0_PLAN.md) to sequence pending PR review: dependency and maintenance work first, then pipeline contracts, then ingest/index changes, then query/API/UI changes, with documentation and changelog updates last. Anything not merged and verified should stay on the roadmap or become follow-up work rather than appearing as shipped 0.4.0 behavior.
+| Area | Status | Public wording until shipped |
+|------|--------|------------------------------|
+| Manifest and registry discovery | Draft design | Entry-point plugins ship today. `alcove.json`, remote registries, and index registry discovery are design notes. |
+| Provenance layer | Partial foundation | Source and collection metadata ship today. Rich provenance manifests and compliance workflows are planned. |
+| Streaming ingest | Planned | Ingest is batch-oriented today. Watch/re-index loops are roadmap work. |
+| Cross-modal indexing | Plugin candidate | Text document extraction ships today. Audio, image, video, OCR, and transcription belong in plugins or future releases. |
+| Multilingual model selection | Exploratory | Operators can choose sentence-transformers through `EMBEDDER`. Per-model multilingual CLI flags and automatic prefix handling are not a shipped public contract. |
+| Richer plugin lifecycle | Planned | Extractor, embedder, and backend entry points ship today. Lifecycle hooks, query transforms, and custom ranking are roadmap work. |
+| Federation | Research | A single local instance ships today. Multi-instance query surfaces without raw-data sharing remain long-term work. |
 
 ## Near-term
 
 **Desktop packaging preparation.** Keep Briefcase metadata public and minimal, document that no desktop app bundle ships yet, and add checks that prevent accidental private paths, hostnames, or release claims from entering packaging files. The first milestone is packaging readiness, not an app-shaped wrapper around an unfinished experience.
 
-**More formats.** RTF, ODT, XLSX. PPTX is now supported by the built-in ingest pipeline. The [extractor plugin API](ARCHITECTURE.md#plugin-system) already supports additional formats; the work is writing and testing each one.
+**More file formats.** RTF, ODT, and XLSX are good extractor-plugin candidates. PPTX support ships in 0.4.0. The current plugin API already supports third-party extractors.
 
-**Semantic search as default.** The hash embedder exists for zero-download offline bootstrapping and for operators who do not want ML in the pipeline. Once the onboarding experience is smooth enough, sentence-transformers (or a lighter alternative) becomes the default install. The hash embedder stays available: not a stepping stone, but a permanent option for people who want deterministic, inspectable results.
+**Browse mode.** Browse mode ships in 0.4.0. Next steps are deeper directory-aware browsing while keeping the surface retrieval-only.
 
-**Browse mode.** Alcove is now navigable, not just searchable: the web UI includes read-only browse pages for recent indexed documents, document detail, collections, file types, authors, and years. Next steps are deeper directory-aware browsing while keeping the surface retrieval-only.
+**Local model hooks.** Ollama embedding support ships in 0.4.0. Near-term work is documentation polish and model-specific guidance, not hosted inference or generated answers.
 
-**Local model hooks.** `EMBEDDER=ollama` now lets operators point Alcove at a local Ollama server for embeddings. Near-term work is documentation polish and model-specific guidance, not hosted inference or generated answers.
-
-**MCP endpoint.** This is the "share it with the universe" part. An MCP-compatible retrieval surface lets AI tools, public-facing websites, or any other tool query your index. The first public step is a local STDIO MCP server that exposes search and collection-listing tools. Your corpus stays local. Your index stays yours. The answers are available to whoever you choose to expose them to. Because Alcove is retrieval, not generation, those answers are what your documents actually say: no hallucinations, no editorializing, no slop. [MCP changes the security surface](SECURITY.md#security-model); review it before exposing the endpoint. Context7 compatibility is a goal.
+**MCP endpoint.** The STDIO MCP retrieval server ships in 0.4.0. Exposing any endpoint changes the security surface; authentication remains the operator's responsibility.
 
 **Release packaging hygiene.** Public releases now include checks for package metadata, release automation, and Homebrew formula safety. PyPI remains the supported public install channel; Homebrew packaging stays deferred until the formula can be generated with public URLs, Apache-2.0 metadata, real release hashes, and vendored Python resources.
 
-**Streaming ingest.** Watch a directory and re-index on change. The current pipeline is batch-oriented: you run `alcove ingest`, it processes everything. Streaming mode keeps the index current without manual intervention.
+**Streaming ingest.** The shipped pipeline is batch-oriented: run ingest, then index. A watcher can keep the index current without manual reruns.
 
-**Provenance and index signing.** Local signing should let operators publish or move index exports with tamper-evident metadata. The first step is Ed25519 signing and verification for document hashes and index export envelopes. Signature verification proves integrity against a public key; identity trust still depends on the operator pinning or verifying the key fingerprint out of band.
+**Provenance improvements.** Source and collection metadata and local signing helpers ship in 0.4.0; richer provenance manifests and compliance workflows remain planned work.
 
-**Runtime deployment controls.** Feature flags and deployment metadata should stay explicit, testable, and file-backed so public builds, local installs, and future hosted demos do not drift through ad hoc environment tweaks.
+**Runtime deployment controls.** Feature flags and deployment metadata ship in 0.4.0. They should stay explicit, testable, and file-backed so public builds, local installs, and future demos do not drift through ad hoc environment tweaks.
 
 ## Mid-term
 
-**Cross-modal indexing.** Audio transcription, image OCR, video keyframe extraction. The pipeline architecture already separates extraction from embedding; new modalities plug in as extractors that produce text chunks from non-text sources. Bioacoustics and field recordings are a motivating use case, not an afterthought.
+**Cross-modal indexing.** Audio transcription, image OCR, and video keyframe extraction fit the same architecture: extractors produce text chunks, embedders index those chunks, and query returns matching source excerpts.
 
-**Relevance as memory, not just distance.** Vector similarity is a starting point. A more useful index would treat recency, frequency of access, and familiarity as first-class relevance signals: things you work with often should surface faster; things you have not touched in years should fade gracefully. This is the Dreyfus-inspired layer: an index that behaves more like memory than search.
+**Relevance as memory, not just distance.** Vector similarity is a starting point. Future ranking can consider recency, frequency of access, and corpus familiarity while preserving the retrieval-only boundary.
 
-**Richer plugin API.** Lifecycle hooks, query-time transformations, custom ranking. The current plugin surface covers extractors, embedders, and backends. Mid-term work expands it to cover more of the pipeline.
+**Richer plugin API.** Lifecycle hooks, query-time transformations, custom ranking, and plugin metadata can extend the current entry-point surface.
 
 ## Long-term
 
-**Federation.** Multiple Alcove instances sharing a query surface without sharing raw data. A research group, a neighborhood archive, a distributed records system: each node owns its corpus, but queries can span the constellation. [Sovereignty is preserved; reach is expanded.](../WHY.md#the-tension-is-the-product)
+**Federation.** Multiple Alcove instances could share a query surface without sharing raw data. Each node would still own its corpus and decide what to expose.
 
 **Desktop application.** A native app for people who should not need a terminal to search their own files. This is packaging and distribution work, not architecture work; the core stays the same. Current status is documented in [Desktop Packaging](DESKTOP.md): Alcove has preparation docs and checks, but no supported desktop bundle yet.
 
 ## Plugin candidates
 
-The [plugin API](ARCHITECTURE.md#plugin-system) exposes three extension points: extractors (`alcove.extractors`), vector backends (`alcove.backends`), and embedders (`alcove.embedders`). Below are concrete candidates for each, with the libraries that would implement them and how they wire into the pipeline.
+The shipped plugin API exposes three extension points: extractors (`alcove.extractors`), embedders (`alcove.embedders`), and vector backends (`alcove.backends`). Candidate plugins should document whether they preserve Alcove's local-first boundary.
 
-**Offline by default.** Alcove makes no outbound network calls unless the operator explicitly selects a cloud plugin. All built-in extractors, embedders, and backends run entirely on the operator's hardware. Selecting a cloud embedder (OpenAI, Cohere) or a cloud backend (Pinecone) changes that: data leaves the machine. This is an operator decision, not a default. Each cloud candidate in the tables below calls this out explicitly.
+### Extractor candidates
 
-### Extractor plugins
+| Candidate | Library | Notes |
+|-----------|---------|-------|
+| RTF | `striprtf` | Legacy text documents. |
+| ODT / ODP / ODS | `odfpy` | OpenDocument text, slides, and sheets. |
+| XLSX | `openpyxl` | Spreadsheet text and tabular metadata. |
+| Audio transcription | `faster-whisper` | Local transcription when models are installed locally. |
+| Image OCR | `pytesseract` or local vision models | Extract searchable text from images. |
 
-Extractors receive a file path and return a list of text chunks. The entry point maps a file extension to a callable: `rtf = my_plugin:extract_rtf`. Plugins override built-ins on name collision.
+### Embedder candidates
 
-| Candidate | Library | Wiring |
-|-----------|---------|--------|
-| RTF | `striprtf` | `ep.name = "rtf"`, callable strips RTF markup → plain text, chunked by paragraph |
-| ODT / ODP / ODS | `odfpy` | `ep.name = "odt"` etc.; parse ODF XML, extract text nodes, chunk by heading or paragraph |
-| XLSX | `openpyxl` | `ep.name = "xlsx"`; iterate sheets and rows, emit one chunk per sheet (column headers + row values as prose) |
-| HTML | `beautifulsoup4` | `ep.name = "html"`; strip tags, extract visible text, chunk by block element |
-| Audio transcription | `faster-whisper` | `ep.name = "mp3"` / `"wav"` / `"m4a"`; transcribe via local Whisper model, emit time-coded text chunks |
-| Image (vision) | `ollama` + LLaVA | `ep.name = "png"` / `"jpg"`; send image to local vision model, return description as a single chunk |
-| Markdown | `markdown` / `mistletoe` | `ep.name = "md"`; parse AST, chunk by heading level |
+| Candidate | Boundary |
+|-----------|----------|
+| Local sentence-transformers variants | Local after first model download. |
+| Ollama or other local model servers | Local if the model server is local. |
+| MLX on Apple Silicon | Local hardware acceleration. |
+| Cloud embedding APIs | Break the default local-only boundary; must be opt-in and documented by the plugin. |
 
-### Embedder plugins
+### Backend candidates
 
-Embedders receive a list of strings and return a list of float vectors. They register on the `alcove.embedders` group and are selected via the `EMBEDDER` env var.
-
-| Candidate | Library | Wiring |
-|-----------|---------|--------|
-| OpenAI | `openai` | Calls `client.embeddings.create(model="text-embedding-3-small", input=texts)`; requires `OPENAI_API_KEY`. Breaks local-only boundary — document this clearly. |
-| Ollama | built-in | Calls a local Ollama server via `EMBEDDER=ollama`; model configured via env vars. Zero-download after first pull. |
-| MLX (Apple Silicon) | `mlx-lm` | Runs embedding model via MLX on M-series GPU; fastest local option for Apple hardware. |
-| Cohere | `cohere` | Calls `co.embed(texts=..., model=...)` via Cohere API; requires API key. Cloud boundary applies. |
-
-### Backend plugins
-
-Backends store and query embedded chunks. They register on the `alcove.backends` group and expose a class that inherits from `VectorBackend`. Selected via `VECTOR_BACKEND` env var.
-
-| Candidate | Library | Wiring |
-|-----------|---------|--------|
-| Qdrant | `qdrant-client` | `QdrantBackend` wraps `QdrantClient`; supports local file mode and remote server. Lighter than ChromaDB for large corpora. |
-| Weaviate | `weaviate-client` | `WeaviateBackend` wraps v4 client; hybrid BM25 + vector search built in. |
-| Pinecone | `pinecone` | `PineconeBackend` is cloud-only; breaks local-first posture. Useful for operators who need managed scale — document the tradeoff. |
-| SQLite-vec | `sqlite-vec` | Embeds vector search directly in a SQLite file; zero external dependencies, single-file corpus portability. Strong fit for the desktop app goal. |
-
-### Plugin interface contract
-
-All three extension points use Python entry points — no framework dependency, no runtime coupling. The contract per type:
-
-- **Extractor**: `(path: str | Path) -> list[str]` — return plain-text chunks. Raise on unreadable files.
-- **Embedder**: class with `embed(texts: list[str]) -> list[list[float]]` — must be deterministic per input if possible; document non-determinism.
-- **Backend**: class with `add(chunks, embeddings, metadatas)`, `query(embedding, k, **filters) -> list[dict]`, `count() -> int`. Match the existing `VectorBackend` ABC in `alcove/index/backend.py`.
-
-**Authentication is out of scope for the plugin system.** The plugin interfaces handle data flow only — extraction, embedding, storage. They provide no authentication mechanism and make no trust decisions. When exposing Alcove endpoints (e.g., the local API or a future MCP surface), authentication must be enforced at the deployment boundary: a reverse proxy, network policy, or OS-level access control. This applies to all three extension types; no plugin implementation should assume the caller is authenticated.
-
-Mid-term roadmap work (lifecycle hooks, query-time transformations) will expand this surface. New groups will follow the same entry-point pattern.
+| Candidate | Boundary |
+|-----------|----------|
+| SQLite-vec | Local single-file index. |
+| Qdrant local mode | Local if configured for local storage. |
+| Remote vector databases | Break the default local-only boundary; must be opt-in and documented by the plugin. |
 
 ## Out of scope
 
-Alcove will not become a hosted service. There is no plan for cloud storage integrations, SaaS features, or a managed offering. The architecture assumes the operator owns the hardware. If that assumption does not hold, Alcove is the wrong tool.
+Alcove will not become a hosted service. There is no plan for mandatory cloud storage, account creation, telemetry, or a managed SaaS offering. If an operator chooses cloud plugins or exposes a local API, that is a deployment decision outside the default Alcove runtime.

--- a/docs/multilingual.md
+++ b/docs/multilingual.md
@@ -1,8 +1,12 @@
 # Multilingual Support
 
-Alcove supports multilingual and cross-lingual search out of the box when a multilingual
-embedding model is configured. No per-language tokenizers, stop-word lists, or query
-parsers are required.
+Status: exploratory guidance. Alcove can use the shipped sentence-transformers embedder
+when `EMBEDDER=sentence-transformers` is set, but v0.4.0 does not expose public CLI flags
+for selecting arbitrary model names or automatic multilingual-E5 prefix handling.
+
+Multilingual and cross-lingual search is possible when an operator configures a suitable
+embedding model through code or a plugin. No per-language tokenizers, stop-word lists, or
+query parsers are required when the chosen model handles those languages.
 
 ---
 
@@ -22,8 +26,8 @@ The asymmetric prefix convention matters:
 | Document at ingest time | `"passage: "` |
 | Query at search time | `"query: "` |
 
-The public alcove codebase applies these prefixes automatically in
-`alcove/index/embedder.py` when a multilingual-e5 model is detected.
+Automatic prefix handling for multilingual-E5 models is planned work, not a shipped
+public contract.
 
 ---
 
@@ -33,11 +37,10 @@ The public alcove codebase applies these prefixes automatically in
 # Install sentence-transformers
 pip install sentence-transformers
 
-# Run with the small multilingual model (384-dim, fast)
-alcove serve --embedder sentence-transformers --model intfloat/multilingual-e5-small
+# Shipped public configuration selects the sentence-transformers embedder.
+EMBEDDER=sentence-transformers alcove serve
 
-# Or the larger model for better cross-lingual precision
-alcove serve --embedder sentence-transformers --model intfloat/multilingual-e5-large
+# Selecting alternate multilingual models requires custom code or a plugin today.
 ```
 
 Model sizes at a glance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "alcove-search"
-version = "0.3.0"
+version = "0.4.0"
 description = "Local-first document retrieval. Your data never leaves your disk."
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/scripts/check_release_plan.py
+++ b/scripts/check_release_plan.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate public-safe release planning docs without creating release artifacts."""
+"""Validate public-safe 0.4.0 release docs before tagging."""
 
 from __future__ import annotations
 
@@ -13,6 +13,7 @@ PLAN_PATH = REPO_ROOT / "docs" / "RELEASE_0_4_0_PLAN.md"
 CHANGELOG_PATH = REPO_ROOT / "CHANGELOG.md"
 ROADMAP_PATH = REPO_ROOT / "docs" / "ROADMAP.md"
 PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+INIT_PATH = REPO_ROOT / "alcove" / "__init__.py"
 
 PUBLIC_DOCS = [
     CHANGELOG_PATH,
@@ -44,10 +45,17 @@ def _project_version() -> str:
     return match.group(1)
 
 
+def _package_version() -> str:
+    match = re.search(r'^__version__ = "([^"]+)"$', _read(INIT_PATH), re.MULTILINE)
+    if not match:
+        return ""
+    return match.group(1)
+
+
 def validate() -> list[str]:
     errors: list[str] = []
 
-    for path in (PLAN_PATH, CHANGELOG_PATH, ROADMAP_PATH, PYPROJECT_PATH):
+    for path in (PLAN_PATH, CHANGELOG_PATH, ROADMAP_PATH, PYPROJECT_PATH, INIT_PATH):
         if not path.exists():
             errors.append(f"missing required file: {path.relative_to(REPO_ROOT)}")
 
@@ -55,34 +63,32 @@ def validate() -> list[str]:
         return errors
 
     package_version = _project_version()
-    if package_version == "1.0.0":
-        errors.append("package version must not be bumped to 1.0.0")
-    if package_version != "0.3.0":
-        errors.append(
-            "planning branch should keep package version at 0.3.0 until release"
-        )
+    if package_version != "0.4.0":
+        errors.append("0.4.0 release branch should set package version to 0.4.0")
+    if _package_version() != package_version:
+        errors.append("alcove.__version__ must match pyproject.toml")
 
     plan = _read(PLAN_PATH)
     changelog = _read(CHANGELOG_PATH)
     roadmap = _read(ROADMAP_PATH)
 
     required_plan_markers = [
-        "Status: planning only.",
-        "Target: 0.4.0 feature-batch release.",
-        "Current package version: 0.3.0 until the release commit.",
-        "## PR Review Sequence",
-        "not as 0.4.0 features",
+        "Status: release-prep complete.",
+        "Target tag: `v0.4.0`.",
+        "Current package version: 0.4.0.",
+        "## Release Scope",
+        "## Release Checklist",
     ]
     for marker in required_plan_markers:
         if marker not in plan:
-            errors.append(f"release plan missing marker: {marker}")
+            errors.append(f"release notes missing marker: {marker}")
 
-    if not re.search(r"^## \[0\.4\.0\] - Planned$", changelog, re.MULTILINE):
-        errors.append("CHANGELOG.md must include a planned 0.4.0 entry")
-    if "not released, not tagged" not in changelog:
-        errors.append("CHANGELOG.md must state that 0.4.0 is not released")
-    if "0.4.0" not in roadmap:
-        errors.append("docs/ROADMAP.md must reference the 0.4.0 planning target")
+    if not re.search(r"^## \[0\.4\.0\] - 2026-05-12$", changelog, re.MULTILINE):
+        errors.append("CHANGELOG.md must include the dated 0.4.0 release entry")
+    if "Current package release (v0.4.0)" not in roadmap:
+        errors.append("docs/ROADMAP.md must describe 0.4.0 as the current package release")
+    if "planning only" in plan or "not released, not tagged" in changelog:
+        errors.append("0.4.0 release docs must not use planning-only language")
 
     for path in PUBLIC_DOCS:
         text = _read(path)
@@ -102,7 +108,7 @@ def main() -> int:
             print(f"ERROR: {error}", file=sys.stderr)
         return 1
 
-    print("release plan checks passed")
+    print("0.4.0 release checks passed")
     return 0
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,4 +31,4 @@ def test_alcove_version():
         capture_output=True, text=True
     )
     assert result.returncode == 0
-    assert "0.3.0" in result.stdout
+    assert "0.4.0" in result.stdout

--- a/tests/test_public_docs_hygiene.py
+++ b/tests/test_public_docs_hygiene.py
@@ -23,21 +23,22 @@ def test_release_checklist_exists_and_has_core_sections() -> None:
     assert "RELEASE_0_4_0_PLAN.md" in text
 
 
-def test_release_0_4_0_plan_is_planning_only() -> None:
+def test_release_0_4_0_docs_are_release_ready() -> None:
     plan = _read("docs/RELEASE_0_4_0_PLAN.md")
     changelog = _read("CHANGELOG.md")
     roadmap = _read("docs/ROADMAP.md")
     pyproject = _read("pyproject.toml")
 
-    assert "Status: planning only." in plan
-    assert "Target: 0.4.0 feature-batch release." in plan
-    assert "## PR Review Sequence" in plan
-    assert "not as 0.4.0 features" in plan
-    assert "## [0.4.0] - Planned" in changelog
-    assert "not released, not tagged" in changelog
-    assert "Next release planning (0.4.0)" in roadmap
-    assert 'version = "0.3.0"' in pyproject
+    assert "Status: release-prep complete." in plan
+    assert "Target tag: `v0.4.0`." in plan
+    assert "Current package version: 0.4.0." in plan
+    assert "## Release Scope" in plan
+    assert "## [0.4.0] - 2026-05-12" in changelog
+    assert "Current package release (v0.4.0)" in roadmap
+    assert 'version = "0.4.0"' in pyproject
     assert 'version = "1.0.0"' not in pyproject
+    assert "planning only" not in plan
+    assert "not released, not tagged" not in changelog
 
 
 def test_release_plan_checker_passes() -> None:
@@ -49,7 +50,7 @@ def test_release_plan_checker_passes() -> None:
         check=False,
     )
     assert result.returncode == 0, result.stderr
-    assert "release plan checks passed" in result.stdout
+    assert "0.4.0 release checks passed" in result.stdout
 
 
 def test_canonical_public_repo_slug_in_metadata_and_docs() -> None:

--- a/tests/test_release_packaging.py
+++ b/tests/test_release_packaging.py
@@ -43,7 +43,7 @@ def test_unsafe_homebrew_formula_is_rejected(tmp_path: Path) -> None:
             [
                 '[project]',
                 'name = "alcove-search"',
-                'version = "0.3.0"',
+                'version = "0.4.0"',
                 'license = {text = "Apache-2.0"}',
                 '',
                 '[project.urls]',


### PR DESCRIPTION
## Summary
- bump package metadata and runtime version to 0.4.0
- convert the 0.4.0 planning docs into release notes/checklist
- sync README, Architecture, Operations, Roadmap, manifest, provenance, and multilingual docs with 0.4.0 scope
- keep draft/planned features clearly separated from released 0.4.0 behavior

## Verification
- python3 scripts/check_release_plan.py
- python3 scripts/check_release_packaging.py
- python3 -m build --sdist --wheel
- python3 -m pytest -q
- git diff --check

## Release note
After this PR merges, tag v0.4.0 to trigger the GitHub Release and PyPI publish workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to clarify the local-first three-stage retrieval pipeline.
  * Revised README to emphasize local-first document retrieval and updated installation/configuration guidance.
  * Enhanced operational guidance with search modes (semantic, keyword, hybrid) and expanded environment variable documentation.
  * Clarified trust model and security boundaries focused on local-only behavior by default.
  * Reorganized roadmap to distinguish shipped v0.4.0 capabilities from pending features.

* **Chores**
  * Bumped package version to 0.4.0.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Spitfire-Cowboy/alcove/pull/131)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->