### PR TITLE
Improve LA laws demo ingestion and search UI

### DIFF
--- a/alcove/index/backend.py
+++ b/alcove/index/backend.py
@@ -9,6 +9,24 @@ from chromadb.config import Settings
 from .embedder import get_collection_name
 
 
+DEFAULT_CHROMA_UPSERT_BATCH_SIZE = 5000
+
+
+def _chroma_upsert_batches(collection, ids, documents, metadatas, embeddings) -> None:
+    batch_size = int(os.getenv("ALCOVE_CHROMA_UPSERT_BATCH_SIZE", DEFAULT_CHROMA_UPSERT_BATCH_SIZE))
+    if batch_size <= 0:
+        raise ValueError("ALCOVE_CHROMA_UPSERT_BATCH_SIZE must be greater than 0")
+
+    for start in range(0, len(ids), batch_size):
+        end = start + batch_size
+        collection.upsert(
+            ids=ids[start:end],
+            documents=documents[start:end],
+            metadatas=metadatas[start:end],
+            embeddings=embeddings[start:end],
+        )
+
+
 class MultiChromaBackend:
     """Vector backend that fans out across ALL ChromaDB collections in CHROMA_PATH.
 
@@ -77,7 +95,8 @@ class MultiChromaBackend:
         for logical, group in groups.items():
             physical = get_collection_name(logical)
             col = self._client.get_or_create_collection(name=physical)
-            col.upsert(
+            _chroma_upsert_batches(
+                col,
                 ids=group["ids"],
                 documents=group["documents"],
                 metadatas=group["metadatas"],
@@ -295,9 +314,7 @@ class ChromaBackend:
         # Ensure every metadata dict has a "collection" key.
         for meta in metadatas:
             meta.setdefault("collection", "default")
-        self._collection.upsert(
-            ids=ids, documents=documents, metadatas=metadatas, embeddings=embeddings,
-        )
+        _chroma_upsert_batches(self._collection, ids, documents, metadatas, embeddings)
 
     def query(self, embedding, k=3, collections: Optional[List[str]] = None):
         kwargs: dict = {"query_embeddings": [embedding], "n_results": k}

--- a/alcove/index/keyword.py
+++ b/alcove/index/keyword.py
@@ -42,6 +42,7 @@ class KeywordIndex:
                         "id": rec.get("id", ""),
                         "text": text,
                         "source": rec.get("source", ""),
+                        "metadata": rec.get("metadata") if isinstance(rec.get("metadata"), dict) else {},
                     })
                     tokenized.append(text.lower().split())
 
@@ -90,11 +91,20 @@ class KeywordIndex:
         ids: List[str] = []
         documents: List[str] = []
         distances: List[float] = []
+        metadatas: List[Dict] = []
 
         for idx, norm in top:
             chunk = self._chunks[idx]
             ids.append(chunk["id"])
             documents.append(chunk["text"])
             distances.append(round(1.0 - norm, 6))
+            meta = dict(chunk.get("metadata") or {})
+            meta.setdefault("source", chunk["source"])
+            metadatas.append(meta)
 
-        return {"ids": [ids], "documents": [documents], "distances": [distances]}
+        return {
+            "ids": [ids],
+            "documents": [documents],
+            "distances": [distances],
+            "metadatas": [metadatas],
+        }

--- a/alcove/query/api.py
+++ b/alcove/query/api.py
@@ -33,7 +33,27 @@ def _root_path() -> str:
 def _tpl(ctx: dict) -> dict:
     """Merge template context with the base_url global."""
     ctx.setdefault("base_url", _root_path())
+    ctx.setdefault("demo", _demo_context())
     return ctx
+
+
+def _demo_context() -> dict:
+    theme = os.getenv("ALCOVE_DEMO_THEME", "").strip().lower()
+    if theme != "la":
+        return {"theme": ""}
+    return {
+        "theme": "la",
+        "title": "Los Angeles Laws",
+        "subtitle": "City Charter, Administrative Code, and Municipal Code",
+        "tagline": "Public civic law search",
+        "default_mode": "keyword",
+        "quick_queries": [
+            "parking of oversize vehicles between 2:00 a.m. and 6:00 a.m.",
+            "minimum wage paid sick leave",
+            "SEC. 41.18 sitting lying sleeping public right-of-way",
+            "independent redistricting commission",
+        ],
+    }
 
 SUPPORTED_EXTENSIONS = {
     ".txt", ".pdf", ".epub",
@@ -163,7 +183,7 @@ def search(request: Request, q: str = "", k: int = 5, collections: str = "", mod
     return templates.TemplateResponse(
         request,
         "results.html",
-        _tpl({"query": q, "results": results}),
+        _tpl({"query": q, "results": results, "mode": mode, "k": k, "collections": collections}),
     )
 
 

--- a/alcove/query/api.py
+++ b/alcove/query/api.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from fastapi import FastAPI, Query, Request, UploadFile, File
-from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from starlette.templating import Jinja2Templates
@@ -55,6 +55,11 @@ class QueryIn(BaseModel):
 @app.get("/health")
 def health():
     return {"ok": True}
+
+
+@app.get("/favicon.ico", include_in_schema=False)
+def favicon():
+    return FileResponse(STATIC_DIR / "favicon.ico")
 
 
 @app.get("/", response_class=HTMLResponse)

--- a/alcove/query/retriever.py
+++ b/alcove/query/retriever.py
@@ -53,19 +53,26 @@ def query_hybrid(
     kw_ids = keyword.get("ids", [[]])[0]
     kw_docs = keyword.get("documents", [[]])[0]
     kw_dists = keyword.get("distances", [[]])[0]
+    kw_metas = keyword.get("metadatas", [[]])[0]
 
-    for doc_id, doc, dist in zip(kw_ids, kw_docs, kw_dists):
+    for i, (doc_id, doc, dist) in enumerate(zip(kw_ids, kw_docs, kw_dists)):
+        kw_meta = kw_metas[i] if i < len(kw_metas) else {}
+        if not isinstance(kw_meta, dict):
+            kw_meta = {}
         if doc_id in merged:
             merged[doc_id]["kw_dist"] = float(dist)
+            merged[doc_id]["metadata"].update(kw_meta)
         else:
             # Keyword-only result: synthesize metadata from doc_id
             # doc_id format is "collection:filename:chunk_idx"
             parts = doc_id.split(":", 1)
             source = parts[1].rsplit(":", 1)[0] if len(parts) > 1 else doc_id
             collection = parts[0] if len(parts) > 1 else "default"
+            metadata = {"source": source, "collection": collection}
+            metadata.update(kw_meta)
             merged[doc_id] = {
                 "document": doc,
-                "metadata": {"source": source, "collection": collection},
+                "metadata": metadata,
                 "sem_dist": None,
                 "kw_dist": float(dist),
             }

--- a/alcove/web/static/style.css
+++ b/alcove/web/static/style.css
@@ -141,21 +141,80 @@ body {
 /* ---- Demo shell: Los Angeles laws ---- */
 
 .demo-la {
-  --bg-body: #151411;
-  --bg-surface: #23211c;
-  --bg-card: #1d1b17;
-  --border: rgba(244, 196, 48, 0.16);
-  --border-hover: rgba(244, 196, 48, 0.42);
-  --gold: #f4c430;
-  --gold-dim: rgba(244, 196, 48, 0.68);
-  --gold-faint: rgba(244, 196, 48, 0.09);
-  --gold-glow: rgba(244, 196, 48, 0.18);
-  --text: #fbf5e6;
-  --text-muted: rgba(251, 245, 230, 0.6);
-  --text-excerpt: rgba(237, 227, 203, 0.86);
-  --scrollbar: #514a33;
-  --la-sky: #56a7b7;
-  --la-sunset: #d85f35;
+  --la-boulevard-sunset: #d24d38;
+  --la-fame-gold: #d69a3a;
+  --la-venice-sand: #d8c29a;
+  --la-hills-white: #e6e8f2;
+  --la-silver-screen: #a9bac2;
+  --la-hockney-blue: #72b7d8;
+  --la-sky: var(--la-hockney-blue);
+  --la-sunset: var(--la-boulevard-sunset);
+}
+
+:root:not([data-theme]) body.demo-la,
+[data-theme="dark"] body.demo-la {
+  color-scheme: dark;
+  --bg-body: #141414;
+  --bg-surface: #22201c;
+  --bg-card: #1b1a17;
+  --border: rgba(216, 194, 154, 0.18);
+  --border-hover: rgba(214, 154, 58, 0.5);
+  --gold: var(--la-fame-gold);
+  --gold-dim: rgba(214, 154, 58, 0.72);
+  --gold-faint: rgba(214, 154, 58, 0.11);
+  --gold-glow: rgba(210, 77, 56, 0.18);
+  --text: #f7f3ea;
+  --text-muted: rgba(247, 243, 234, 0.62);
+  --text-excerpt: rgba(230, 232, 242, 0.82);
+  --scrollbar: #5f573e;
+  --la-header-bg: rgba(20, 20, 20, 0.9);
+  --la-search-bg: rgba(27, 26, 23, 0.96);
+  --la-card-sheen: rgba(114, 183, 216, 0.035);
+  --la-mark-text: #ffe2a2;
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) body.demo-la {
+    color-scheme: light;
+    --bg-body: var(--la-hills-white);
+    --bg-surface: #f7f3ea;
+    --bg-card: #fffdf8;
+    --border: rgba(96, 92, 82, 0.18);
+    --border-hover: rgba(210, 77, 56, 0.44);
+    --gold: #9d640e;
+    --gold-dim: rgba(96, 76, 44, 0.68);
+    --gold-faint: rgba(214, 154, 58, 0.13);
+    --gold-glow: rgba(114, 183, 216, 0.22);
+    --text: #171615;
+    --text-muted: rgba(23, 22, 21, 0.62);
+    --text-excerpt: rgba(51, 45, 34, 0.9);
+    --scrollbar: var(--la-silver-screen);
+    --la-header-bg: rgba(230, 232, 242, 0.9);
+    --la-search-bg: rgba(255, 253, 248, 0.97);
+    --la-card-sheen: rgba(114, 183, 216, 0.055);
+    --la-mark-text: #643f00;
+  }
+}
+
+[data-theme="light"] body.demo-la {
+  color-scheme: light;
+  --bg-body: var(--la-hills-white);
+  --bg-surface: #f7f3ea;
+  --bg-card: #fffdf8;
+  --border: rgba(96, 92, 82, 0.18);
+  --border-hover: rgba(210, 77, 56, 0.44);
+  --gold: #9d640e;
+  --gold-dim: rgba(96, 76, 44, 0.68);
+  --gold-faint: rgba(214, 154, 58, 0.13);
+  --gold-glow: rgba(114, 183, 216, 0.22);
+  --text: #171615;
+  --text-muted: rgba(23, 22, 21, 0.62);
+  --text-excerpt: rgba(51, 45, 34, 0.9);
+  --scrollbar: var(--la-silver-screen);
+  --la-header-bg: rgba(230, 232, 242, 0.9);
+  --la-search-bg: rgba(255, 253, 248, 0.97);
+  --la-card-sheen: rgba(114, 183, 216, 0.055);
+  --la-mark-text: #643f00;
 }
 
 .demo-sidebar {
@@ -171,6 +230,12 @@ body {
   flex-direction: column;
   gap: 1.25rem;
   z-index: 70;
+}
+
+[data-theme="light"] body.demo-la .demo-sidebar {
+  background:
+    linear-gradient(180deg, rgba(114, 183, 216, 0.22), transparent 38%),
+    #f2e6cf;
 }
 
 .demo-brand {
@@ -242,7 +307,7 @@ body {
   font-size: 0.86rem;
   line-height: 1.25;
   text-decoration: none;
-  background: rgba(255, 255, 255, 0.025);
+  background: var(--gold-faint);
 }
 
 .demo-sidebar-nav a:hover {
@@ -272,7 +337,7 @@ body {
   padding: 1.1rem 0 0.9rem;
   text-align: left;
   border-bottom: 1px solid var(--border);
-  background: rgba(21, 20, 17, 0.88);
+  background: var(--la-header-bg);
   backdrop-filter: blur(14px);
   position: sticky;
   top: 0;
@@ -338,7 +403,7 @@ body {
 }
 
 .demo-la .search-form {
-  background: rgba(29, 27, 23, 0.94);
+  background: var(--la-search-bg);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   padding: 0.7rem;
@@ -376,7 +441,7 @@ body {
   border-radius: var(--radius-md);
   padding: 1rem;
   background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0)),
+    linear-gradient(180deg, var(--la-card-sheen), transparent),
     var(--bg-card);
 }
 
@@ -401,7 +466,7 @@ body {
 
 .demo-la mark {
   background: rgba(244, 196, 48, 0.18);
-  color: #ffe07b;
+  color: var(--la-mark-text);
 }
 
 /* ---- Accessibility ---- */

--- a/alcove/web/static/style.css
+++ b/alcove/web/static/style.css
@@ -138,6 +138,272 @@ body {
   padding: 0 1.5rem;
 }
 
+/* ---- Demo shell: Los Angeles laws ---- */
+
+.demo-la {
+  --bg-body: #151411;
+  --bg-surface: #23211c;
+  --bg-card: #1d1b17;
+  --border: rgba(244, 196, 48, 0.16);
+  --border-hover: rgba(244, 196, 48, 0.42);
+  --gold: #f4c430;
+  --gold-dim: rgba(244, 196, 48, 0.68);
+  --gold-faint: rgba(244, 196, 48, 0.09);
+  --gold-glow: rgba(244, 196, 48, 0.18);
+  --text: #fbf5e6;
+  --text-muted: rgba(251, 245, 230, 0.6);
+  --text-excerpt: rgba(237, 227, 203, 0.86);
+  --scrollbar: #514a33;
+  --la-sky: #56a7b7;
+  --la-sunset: #d85f35;
+}
+
+.demo-sidebar {
+  position: fixed;
+  inset: 0 auto 0 0;
+  width: 288px;
+  padding: 1.1rem;
+  background:
+    linear-gradient(180deg, rgba(244, 196, 48, 0.08), transparent 34%),
+    var(--bg-card);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  z-index: 70;
+}
+
+.demo-brand {
+  display: flex;
+  gap: 0.8rem;
+  align-items: center;
+  color: var(--text);
+  text-decoration: none;
+  min-width: 0;
+}
+
+.demo-brand:hover {
+  text-decoration: none;
+}
+
+.demo-brand-mark {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, var(--gold), var(--la-sunset));
+  color: #151411;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  font-weight: 800;
+  letter-spacing: 0;
+}
+
+.demo-brand-title,
+.demo-brand-subtitle,
+.demo-nav-label,
+.demo-sidebar-meta span {
+  display: block;
+}
+
+.demo-brand-title {
+  font-weight: 800;
+  line-height: 1.05;
+}
+
+.demo-brand-subtitle {
+  color: var(--text-muted);
+  font-size: 0.76rem;
+  line-height: 1.25;
+  margin-top: 0.2rem;
+}
+
+.demo-sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.demo-nav-label {
+  color: var(--gold-dim);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  margin-bottom: 0.2rem;
+}
+
+.demo-sidebar-nav a {
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 0.62rem 0.72rem;
+  font-size: 0.86rem;
+  line-height: 1.25;
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.demo-sidebar-nav a:hover {
+  border-color: var(--border-hover);
+  background: var(--gold-faint);
+  text-decoration: none;
+}
+
+.demo-sidebar-meta {
+  margin-top: auto;
+  border-top: 1px solid var(--border);
+  padding-top: 0.9rem;
+  color: var(--text-muted);
+  font-size: 0.76rem;
+  line-height: 1.6;
+}
+
+.demo-la .page-wrap {
+  padding-left: 288px;
+}
+
+.demo-la .container {
+  max-width: 1040px;
+}
+
+.demo-la .site-header {
+  padding: 1.1rem 0 0.9rem;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  background: rgba(21, 20, 17, 0.88);
+  backdrop-filter: blur(14px);
+  position: sticky;
+  top: 0;
+  z-index: 60;
+}
+
+.demo-la .site-header .container {
+  align-items: center;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.demo-la .site-tagline {
+  display: none;
+}
+
+.demo-la .site-nav {
+  padding-right: 3.25rem;
+}
+
+.demo-la .logo-mark {
+  background: var(--la-sky);
+  color: #081315;
+  letter-spacing: 0;
+}
+
+.demo-la .site-main {
+  padding-top: 1rem;
+}
+
+.demo-la .hero-panel,
+.demo-la .workspace-panel,
+.demo-la .trust-strip,
+.demo-la .upload-zone,
+.demo-la .formats-note,
+.demo-la .hero-actions,
+.demo-la .hero-use-cases,
+.demo-la .welcome-banner {
+  display: none;
+}
+
+.demo-la .landing-shell {
+  gap: 0;
+}
+
+.demo-la .workspace-panel {
+  display: block;
+  padding: 1rem;
+  background: var(--bg-card);
+}
+
+.demo-la .workspace-header {
+  margin-bottom: 1rem;
+}
+
+.demo-la .workspace-header .quickstart-card,
+.demo-la .workspace-header .section-kicker {
+  display: none;
+}
+
+.demo-la .workspace-header h3 {
+  font-size: 1.05rem;
+}
+
+.demo-la .search-form {
+  background: rgba(29, 27, 23, 0.94);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 0.7rem;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.28);
+}
+
+.demo-la .workspace-panel .search-form {
+  position: sticky;
+  top: 5.25rem;
+  z-index: 50;
+}
+
+.sticky-search-form {
+  position: sticky;
+  top: 0.75rem;
+  z-index: 50;
+  align-items: center;
+}
+
+.demo-la .sticky-search-form {
+  top: 5.25rem;
+  margin-bottom: 1rem;
+}
+
+.compact-search-mode {
+  margin: 0;
+  flex: 0 0 auto;
+}
+
+.demo-la .results-header {
+  padding-top: 0.1rem;
+}
+
+.demo-la .result-card {
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0)),
+    var(--bg-card);
+}
+
+.demo-la .result-filename {
+  white-space: normal;
+  line-height: 1.25;
+}
+
+.demo-la .file-type-icon {
+  background: rgba(86, 167, 183, 0.14);
+  border-color: rgba(86, 167, 183, 0.34);
+  color: var(--la-sky);
+}
+
+.demo-la .result-chunk {
+  color: var(--text-excerpt);
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.75;
+  border-left-color: rgba(86, 167, 183, 0.45);
+}
+
+.demo-la mark {
+  background: rgba(244, 196, 48, 0.18);
+  color: #ffe07b;
+}
+
 /* ---- Accessibility ---- */
 
 .sr-only {
@@ -1148,5 +1414,56 @@ a:hover {
 
   .result-chunk {
     font-size: 0.875rem;
+  }
+}
+
+@media (max-width: 980px) {
+  .demo-sidebar {
+    position: sticky;
+    top: 0;
+    width: auto;
+    inset: auto;
+    padding: 0.9rem 1rem;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .demo-sidebar-nav,
+  .demo-sidebar-meta {
+    display: none;
+  }
+
+  .demo-la .page-wrap {
+    padding-left: 0;
+  }
+
+  .demo-la .site-header {
+    top: 73px;
+  }
+
+  .demo-la .workspace-panel .search-form,
+  .demo-la .sticky-search-form {
+    top: 8.4rem;
+  }
+
+  .compact-search-mode {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 720px) {
+  .demo-la .site-header .container {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .demo-la .search-form {
+    flex-direction: column;
+  }
+
+  .demo-la .workspace-panel .search-form,
+  .demo-la .sticky-search-form {
+    top: 9.8rem;
   }
 }

--- a/alcove/web/static/style.css
+++ b/alcove/web/static/style.css
@@ -330,11 +330,11 @@ body {
 }
 
 .demo-la .container {
-  max-width: 1040px;
+  max-width: 1180px;
 }
 
 .demo-la .site-header {
-  padding: 1.1rem 0 0.9rem;
+  padding: 1rem 0;
   text-align: left;
   border-bottom: 1px solid var(--border);
   background: var(--la-header-bg);
@@ -362,10 +362,17 @@ body {
   background: var(--la-sky);
   color: #081315;
   letter-spacing: 0;
+  box-shadow: 0 10px 24px rgba(114, 183, 216, 0.22);
+}
+
+.demo-la .site-title {
+  font-size: clamp(1.65rem, 2vw, 2.1rem);
+  letter-spacing: 0;
 }
 
 .demo-la .site-main {
-  padding-top: 1rem;
+  padding-top: 1.35rem;
+  padding-bottom: 2.25rem;
 }
 
 .demo-la .hero-panel,
@@ -385,8 +392,11 @@ body {
 
 .demo-la .workspace-panel {
   display: block;
-  padding: 1rem;
-  background: var(--bg-card);
+  padding: 1rem 1.1rem;
+  background:
+    linear-gradient(135deg, var(--la-card-sheen), transparent 44%),
+    var(--bg-card);
+  border-radius: var(--radius-lg);
 }
 
 .demo-la .workspace-header {
@@ -406,8 +416,9 @@ body {
   background: var(--la-search-bg);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  padding: 0.7rem;
-  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.28);
+  padding: 0.55rem;
+  box-shadow: 0 16px 42px rgba(24, 34, 43, 0.13);
+  gap: 0.55rem;
 }
 
 .demo-la .workspace-panel .search-form {
@@ -425,7 +436,7 @@ body {
 
 .demo-la .sticky-search-form {
   top: 5.25rem;
-  margin-bottom: 1rem;
+  margin-bottom: 1.35rem;
 }
 
 .compact-search-mode {
@@ -433,21 +444,66 @@ body {
   flex: 0 0 auto;
 }
 
+.demo-la .search-input-wrap {
+  min-width: 260px;
+}
+
+.demo-la .search-form input[type="text"] {
+  min-height: 48px;
+  border-radius: var(--radius-md);
+  font-size: 0.98rem;
+  background: var(--bg-surface);
+}
+
+.demo-la .search-btn {
+  min-height: 48px;
+  border-radius: var(--radius-md);
+  background: var(--gold);
+  color: var(--bg-card);
+  font-weight: 750;
+  padding: 0.65rem 1.25rem;
+}
+
+.demo-la .search-btn:hover {
+  background: var(--la-boulevard-sunset);
+  border-color: var(--la-boulevard-sunset);
+  color: #fffdf8;
+}
+
+.demo-la .search-mode-selector {
+  gap: 0.55rem;
+}
+
+.demo-la .mode-option {
+  font-size: 0.86rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
 .demo-la .results-header {
   padding-top: 0.1rem;
+  margin-bottom: 0.8rem;
 }
 
 .demo-la .result-card {
   border-radius: var(--radius-md);
-  padding: 1rem;
+  padding: 1.05rem 1.15rem;
   background:
     linear-gradient(180deg, var(--la-card-sheen), transparent),
     var(--bg-card);
+  box-shadow: 0 18px 52px rgba(24, 34, 43, 0.09);
+}
+
+.demo-la .result-meta {
+  margin-bottom: 0.8rem;
+  align-items: center;
 }
 
 .demo-la .result-filename {
   white-space: normal;
   line-height: 1.25;
+  font-size: 1.02rem;
+  max-width: 68ch;
 }
 
 .demo-la .file-type-icon {
@@ -460,13 +516,26 @@ body {
   color: var(--text-excerpt);
   font-style: normal;
   font-weight: 400;
-  line-height: 1.75;
+  font-size: 0.98rem;
+  line-height: 1.65;
   border-left-color: rgba(86, 167, 183, 0.45);
+  max-width: 92ch;
 }
 
 .demo-la mark {
-  background: rgba(244, 196, 48, 0.18);
+  background: var(--gold-faint);
   color: var(--la-mark-text);
+  border-radius: 4px;
+  padding: 0 0.18em;
+}
+
+.demo-la .score-bar-wrap {
+  height: 5px;
+}
+
+.demo-la .collection-badge {
+  color: var(--text-muted);
+  font-size: 0.86rem;
 }
 
 /* ---- Accessibility ---- */

--- a/alcove/web/templates/base.html
+++ b/alcove/web/templates/base.html
@@ -13,9 +13,29 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  {% if demo.theme == "la" %}
+  <script>
+    tailwind = {
+      config: {
+        theme: {
+          extend: {
+            colors: {
+              laGold: "#f4c430",
+              laSky: "#56a7b7",
+              laSunset: "#d85f35",
+              laInk: "#151411",
+              laCream: "#f7f1e4"
+            }
+          }
+        }
+      }
+    };
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  {% endif %}
   <link rel="stylesheet" href="{{ base_url }}/static/style.css">
 </head>
-<body>
+<body class="{% if demo.theme %}demo-{{ demo.theme }}{% endif %}">
   <a href="#main-content" class="skip-link">Skip to main content</a>
 
   <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
@@ -23,13 +43,35 @@
   </button>
 
   <div class="page-wrap">
+    {% if demo.theme == "la" %}
+    <aside class="demo-sidebar shadow-2xl shadow-black/30" aria-label="Los Angeles laws navigation">
+      <a class="demo-brand group" href="{{ base_url }}/">
+        <span class="demo-brand-mark transition-transform group-hover:scale-105" aria-hidden="true">LA</span>
+        <span>
+          <span class="demo-brand-title">{{ demo.title }}</span>
+          <span class="demo-brand-subtitle">{{ demo.subtitle }}</span>
+        </span>
+      </a>
+      <nav class="demo-sidebar-nav" aria-label="Common searches">
+        <span class="demo-nav-label">Common Searches</span>
+        {% for item in demo.quick_queries %}
+        <a class="transition-colors" href="{{ base_url }}/search?q={{ item | urlencode }}&mode={{ demo.default_mode }}&k=5">{{ item }}</a>
+        {% endfor %}
+      </nav>
+      <div class="demo-sidebar-meta space-y-1">
+        <span>Current through March 31, 2026</span>
+        <span>Retrieval only</span>
+      </div>
+    </aside>
+    {% endif %}
+
     <header class="site-header">
       <div class="container">
         <div class="logo-row">
-          <div class="logo-mark" aria-hidden="true">A</div>
-          <h1 class="site-title">Alcove</h1>
+          <div class="logo-mark" aria-hidden="true">{% if demo.theme == "la" %}LA{% else %}A{% endif %}</div>
+          <h1 class="site-title">{% if demo.theme == "la" %}Los Angeles Laws{% else %}Alcove{% endif %}</h1>
         </div>
-        <p class="site-tagline">Local-first retrieval</p>
+        <p class="site-tagline">{% if demo.theme == "la" %}{{ demo.tagline }}{% else %}Local-first retrieval{% endif %}</p>
         <nav class="site-nav" aria-label="Primary">
           <a href="{{ base_url }}/">Search</a>
           <a href="{{ base_url }}/browse">Browse</a>
@@ -47,7 +89,11 @@
       <div class="container">
         <p>
           <span class="footer-dot" aria-hidden="true"></span>
+          {% if demo.theme == "la" %}
+          Public LA laws search demo powered by Alcove.
+          {% else %}
           Runs locally. No cloud. No telemetry.
+          {% endif %}
         </p>
       </div>
     </footer>

--- a/alcove/web/templates/results.html
+++ b/alcove/web/templates/results.html
@@ -1,6 +1,37 @@
 {% extends "base.html" %}
 
 {% block content %}
+  <form class="search-form sticky-search-form" method="GET" action="{{ base_url }}/search" role="search" aria-label="Search again">
+    <label for="results-search-input" class="sr-only">Search Los Angeles laws</label>
+    <div class="search-input-wrap">
+      <span class="search-icon" aria-hidden="true">&#128269;</span>
+      <input
+        id="results-search-input"
+        type="text"
+        name="q"
+        value="{{ query | e }}"
+        placeholder="Search by section, topic, or phrase..."
+        aria-label="Search your documents">
+    </div>
+    <input type="hidden" name="collections" value="{{ collections | e }}">
+    <fieldset class="search-mode-selector compact-search-mode" role="radiogroup" aria-label="Search mode">
+      <label class="mode-option">
+        <input type="radio" name="mode" value="semantic" {% if mode == "semantic" %}checked{% endif %}>
+        <span class="mode-label">Semantic</span>
+      </label>
+      <label class="mode-option">
+        <input type="radio" name="mode" value="keyword" {% if mode == "keyword" %}checked{% endif %}>
+        <span class="mode-label">Keyword</span>
+      </label>
+      <label class="mode-option">
+        <input type="radio" name="mode" value="hybrid" {% if mode == "hybrid" %}checked{% endif %}>
+        <span class="mode-label">Hybrid</span>
+      </label>
+    </fieldset>
+    <input type="hidden" name="k" value="{{ k }}">
+    <button type="submit" class="search-btn">Search</button>
+  </form>
+
   {% if results %}
   <div class="results-header">
     <span class="results-count">{{ results | length }} result{% if results | length != 1 %}s{% endif %} for</span>

--- a/alcove/web/templates/search.html
+++ b/alcove/web/templates/search.html
@@ -4,11 +4,15 @@
   <div class="landing-shell">
     <section class="hero-panel">
       <div class="hero-copy">
-        <p class="eyebrow">Local-first retrieval for operators who keep the disk.</p>
-        <h2 class="hero-title">Index your world. Search it without handing it over.</h2>
+        <p class="eyebrow">{% if demo.theme == "la" %}Los Angeles civic law search{% else %}Local-first retrieval for operators who keep the disk.{% endif %}</p>
+        <h2 class="hero-title">{% if demo.theme == "la" %}Search Los Angeles laws by section.{% else %}Index your world. Search it without handing it over.{% endif %}</h2>
         <p class="hero-lede">
+          {% if demo.theme == "la" %}
+          Search Los Angeles city law by section, topic, and exact legal phrase.
+          {% else %}
           Alcove ingests a directory of documents, builds a local semantic index, and serves fast search on
           localhost. No cloud account. No telemetry. No custody transfer.
+          {% endif %}
         </p>
         <div class="hero-actions">
           <a class="hero-link hero-link-primary" href="#workspace">Try the local workspace</a>
@@ -33,8 +37,8 @@
 
       <section class="hero-use-cases" aria-labelledby="use-cases-heading">
         <div class="section-heading">
-          <p class="section-kicker">Lead with the use cases</p>
-          <h3 id="use-cases-heading">Built for collections that should stay on your machine</h3>
+          <p class="section-kicker">{% if demo.theme == "la" %}Explore the corpus{% else %}Lead with the use cases{% endif %}</p>
+          <h3 id="use-cases-heading">{% if demo.theme == "la" %}Built for public city law lookup{% else %}Built for collections that should stay on your machine{% endif %}</h3>
         </div>
         <div class="use-case-grid">
           <article class="use-case-card">
@@ -69,8 +73,8 @@
       </article>
       <article class="trust-card">
         <span class="trust-step">03</span>
-        <h3>Serve search on localhost</h3>
-        <p>Operators get a web interface that stays near the source material instead of sending it into a control plane.</p>
+          <h3>{% if demo.theme == "la" %}Serve a public demo{% else %}Serve search on localhost{% endif %}</h3>
+          <p>{% if demo.theme == "la" %}Visitors get a focused search surface over public civic source material.{% else %}Operators get a web interface that stays near the source material instead of sending it into a control plane.{% endif %}</p>
       </article>
     </section>
 
@@ -111,11 +115,11 @@
 
         <fieldset class="search-mode-selector" role="radiogroup" aria-label="Search mode">
           <label class="mode-option">
-            <input type="radio" name="mode" value="semantic" checked>
+            <input type="radio" name="mode" value="semantic" {% if demo.default_mode != "keyword" %}checked{% endif %}>
             <span class="mode-label">Semantic</span>
           </label>
           <label class="mode-option">
-            <input type="radio" name="mode" value="keyword">
+            <input type="radio" name="mode" value="keyword" {% if demo.default_mode == "keyword" %}checked{% endif %}>
             <span class="mode-label">Keyword</span>
           </label>
           <label class="mode-option">

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -175,3 +175,10 @@ class TestStylesheet:
 
     def test_amber_badge_variable(self):
         assert "--amber-badge" in self.css
+
+    def test_la_demo_theme_has_distinct_light_and_dark_tokens(self):
+        assert ":root:not([data-theme]) body.demo-la" in self.css
+        assert '[data-theme="dark"] body.demo-la' in self.css
+        assert '[data-theme="light"] body.demo-la' in self.css
+        assert "--la-boulevard-sunset" in self.css
+        assert "--la-hockney-blue" in self.css

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -72,7 +72,7 @@ class TestSearchTemplate:
     def test_use_cases_heading_present(self):
         html = _read("search.html")
         assert 'id="use-cases-heading"' in html
-        assert 'id="use-cases-heading">Built for collections that should stay on your machine<' in html
+        assert "Built for collections that should stay on your machine" in html
 
     def test_workspace_section_present(self):
         html = _read("search.html")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,6 +24,26 @@ def test_root_returns_html():
     assert "alcove seed-demo" in r.text
 
 
+def test_la_demo_theme_changes_public_positioning(monkeypatch):
+    monkeypatch.setenv("ALCOVE_DEMO_THEME", "la")
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "Los Angeles Laws" in r.text
+    assert "Public civic law search" in r.text
+    assert "Local-first retrieval" not in r.text
+    assert "Runs locally. No cloud. No telemetry." not in r.text
+    assert "cdn.tailwindcss.com" in r.text
+    assert "demo-sidebar" in r.text
+
+
+def test_results_page_has_sticky_search(monkeypatch):
+    monkeypatch.setenv("ALCOVE_DEMO_THEME", "la")
+    r = client.get("/search", params={"q": "minimum wage", "mode": "keyword", "k": 3})
+    assert r.status_code == 200
+    assert "sticky-search-form" in r.text
+    assert 'value="minimum wage"' in r.text
+
+
 def test_query_post_returns_json():
     """Query endpoint works even with empty index (returns empty results)."""
     r = client.post("/query", json={"query": "test", "k": 1})

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -161,6 +162,25 @@ def test_zvec_iter_metadata_records_returns_source_and_collection():
         {"source": "a.txt", "collection": "letters"},
         {"source": "b.txt", "collection": "default"},
     ]
+
+
+class TestChromaBatching:
+    def test_add_batches_large_chroma_upserts(self, monkeypatch):
+        monkeypatch.setenv("ALCOVE_CHROMA_UPSERT_BATCH_SIZE", "2")
+        from alcove.index.backend import _chroma_upsert_batches
+
+        collection = MagicMock()
+        ids = ["d1", "d2", "d3", "d4", "d5"]
+        docs = [f"doc {i}" for i in ids]
+        metas = [{"source": f"{i}.txt"} for i in ids]
+        embeddings = [[float(i)] for i in range(len(ids))]
+
+        _chroma_upsert_batches(collection, ids, docs, metas, embeddings)
+
+        assert collection.upsert.call_count == 3
+        assert collection.upsert.call_args_list[0].kwargs["ids"] == ["d1", "d2"]
+        assert collection.upsert.call_args_list[1].kwargs["ids"] == ["d3", "d4"]
+        assert collection.upsert.call_args_list[2].kwargs["ids"] == ["d5"]
 
 
 @_skip_zvec

--- a/tests/test_keyword.py
+++ b/tests/test_keyword.py
@@ -58,12 +58,20 @@ class TestKeywordIndex:
         assert "ids" in result
         assert "documents" in result
         assert "distances" in result
+        assert "metadatas" in result
         # Outer list wrapper (ChromaDB convention)
         assert len(result["ids"]) == 1
         assert len(result["documents"]) == 1
         assert len(result["distances"]) == 1
+        assert len(result["metadatas"]) == 1
         # Should return at most k results
         assert len(result["ids"][0]) <= 2
+
+    def test_search_returns_source_metadata(self, chunks_file):
+        idx = KeywordIndex(chunks_file=chunks_file)
+        result = idx.search("brown fox", k=1)
+
+        assert result["metadatas"][0][0]["source"] == "a.txt"
 
     def test_search_ranks_relevant_doc_first(self, chunks_file):
         idx = KeywordIndex(chunks_file=chunks_file)
@@ -132,6 +140,7 @@ class TestHybridMerge:
             "ids": [["doc1", "doc3"]],
             "documents": [["text1", "text3"]],
             "distances": [[0.3, 0.4]],
+            "metadatas": [[{"source": "text1.txt"}, {"source": "text3.txt"}]],
         }
 
         monkeypatch.setattr(
@@ -158,6 +167,7 @@ class TestHybridMerge:
         # Should have all 3 unique docs
         assert len(ids) == 3
         assert set(ids) == {"doc1", "doc2", "doc3"}
+        assert result["metadatas"][0][0]["source"] == "text1.txt"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- batch ChromaDB upserts so large corpora do not exceed local max batch limits
- preserve keyword result metadata so web/API results show human-readable section sources
- add an opt-in LA laws demo theme with a sidebar, sticky search bar, Tailwind CDN styling hooks, and LA colour-palette treatment
- refine the LA design sweep around Boulevard Sunset, Fame Gold, Venice Sand, Hills White, Silver Screen, and Hockney Blue
- fix LA demo light/dark toggle tokens so theme changes are visible
- serve /favicon.ico from the app

## Why
The LA laws corpus produced 15,963 section chunks. Without batching, indexing can exceed the local Chroma max batch size. Without keyword metadata, the demo UI shows opaque chunk ids instead of section titles. The LA demo also needs to present as a public civic law search demo, not as a generic local-first Alcove landing page.

## Tests
- python3 -m pytest tests/test_backend.py tests/test_pipeline_empty.py tests/test_cli.py
- python3 -m pytest tests/test_keyword.py tests/test_backend.py tests/test_cli.py
- python3 -m pytest tests/test_api.py tests/test_accessibility.py tests/test_keyword.py
- python3 -m pytest tests/test_accessibility.py tests/test_api.py

## Local QA
- running at http://127.0.0.1:8001 with ALCOVE_DEMO_THEME=la
- browser-checked results page for `minimum wage paid sick leave`
- latest screenshot: `la-demo-design-sweep.png`