### PR TITLE
Point sponsor button at Spitfire Cowboy

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: [Pro777]
+github: [Spitfire-Cowboy]


### PR DESCRIPTION
Updates .github/FUNDING.yml so the repository Sponsor button points to the Spitfire-Cowboy GitHub Sponsors account now that sponsorships are enabled for the public repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Sponsors funding configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Spitfire-Cowboy/alcove/pull/135)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->