### PR TITLE
Fix sponsor button funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: [Spitfire-Cowboy]
+custom: ["https://github.com/Spitfire-Cowboy/alcove"]


### PR DESCRIPTION
Updates FUNDING.yml to use a custom working GitHub URL because the GitHub Sponsors target is currently not active and renders an empty Sponsor panel.