### PR TITLE
Use Ko-fi sponsor link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: ["https://github.com/Spitfire-Cowboy/alcove"]
+custom: ["https://ko-fi.com/spitfirecowboy"]


### PR DESCRIPTION
## Summary
- Update the public repository funding metadata to point at the working Ko-fi sponsorship page
- Avoid the inactive GitHub Sponsors URL

## Tests
- Not run; metadata-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project's funding configuration to direct users to Ko-fi for sponsorship opportunities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Spitfire-Cowboy/alcove/pull/137)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->