### PR TITLE
add dependency integrity verifier

### DIFF
--- a/constraints/base-runtime.txt
+++ b/constraints/base-runtime.txt
@@ -1,0 +1,12 @@
+# Public base-runtime constraints for release verification and low-trust installs.
+# Keep this file aligned with [project.dependencies] in pyproject.toml.
+chromadb>=1.0,<2.0
+fastapi>=0.115.0,<1.0
+uvicorn>=0.30.0,<1.0
+pypdf>=6.7.5,<7.0
+beautifulsoup4>=4.12,<5.0
+jinja2>=3.1,<4.0
+python-multipart>=0.0.6,<1.0
+rank-bm25>=0.2
+cryptography>=41.0,<49.0
+tomli>=2.0,<3.0; python_version < '3.11'

--- a/constraints/base-runtime.txt
+++ b/constraints/base-runtime.txt
@@ -7,6 +7,6 @@ pypdf>=6.7.5,<7.0
 beautifulsoup4>=4.12,<5.0
 jinja2>=3.1,<4.0
 python-multipart>=0.0.6,<1.0
-rank-bm25>=0.2
+rank-bm25>=0.2,<0.3
 cryptography>=41.0,<49.0
 tomli>=2.0,<3.0; python_version < '3.11'

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -24,6 +24,22 @@ alcove serve
 
 The base install uses the hash embedder. It is deterministic and offline, but it is not a semantic model.
 
+## Dependency verification
+
+For low-trust or release-verification environments, keep installs aligned with the public base-runtime constraints:
+
+```bash
+pip install -c constraints/base-runtime.txt .
+python3 scripts/check_dependency_integrity.py
+```
+
+The verifier reports three things:
+- whether `constraints/base-runtime.txt` still matches `[project.dependencies]` in `pyproject.toml`
+- whether installed package versions satisfy the public base-runtime constraints
+- which installed packages include native extensions, which are the highest-trust dependency artifacts to review first
+
+For development, install the extras you need on top of the same base constraints. The public repo does not ship a full hash-pinned lockfile; the maintained contract today is the checked-in constraints file plus the drift report.
+
 ## Local Ollama embeddings
 
 If you already run Ollama locally, Alcove can use an embedding model served from that local process:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "beautifulsoup4>=4.12,<5.0",
     "jinja2>=3.1,<4.0",
     "python-multipart>=0.0.6,<1.0",
-    "rank-bm25>=0.2",
+    "rank-bm25>=0.2,<0.3",
     "cryptography>=41.0,<49.0",
     "tomli>=2.0,<3.0; python_version < '3.11'",
 ]

--- a/scripts/check_dependency_integrity.py
+++ b/scripts/check_dependency_integrity.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
+
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+
+_NATIVE_SUFFIXES = {".so", ".pyd", ".dylib", ".dll"}
+
+
+@dataclass(frozen=True)
+class ConstraintStatus:
+    requirement: str
+    name: str
+    installed: str | None
+    status: str
+    has_native_extensions: bool
+
+
+def load_pyproject_requirements(pyproject_path: Path) -> list[str]:
+    with pyproject_path.open("rb") as fp:
+        data = tomllib.load(fp)
+    return list(data["project"]["dependencies"])
+
+
+def load_constraints(constraints_path: Path) -> list[str]:
+    requirements: list[str] = []
+    for line in constraints_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        requirements.append(stripped)
+    return requirements
+
+
+def check_constraints(
+    *,
+    pyproject_path: Path,
+    constraints_path: Path,
+) -> dict[str, object]:
+    pyproject_reqs = load_pyproject_requirements(pyproject_path)
+    constraint_reqs = load_constraints(constraints_path)
+
+    pyproject_set = set(pyproject_reqs)
+    constraints_set = set(constraint_reqs)
+
+    statuses = [evaluate_requirement(req) for req in constraint_reqs]
+    return {
+        "constraints_path": str(constraints_path),
+        "pyproject_path": str(pyproject_path),
+        "missing_from_constraints": sorted(pyproject_set - constraints_set),
+        "extra_in_constraints": sorted(constraints_set - pyproject_set),
+        "requirements": [status.__dict__ for status in statuses],
+    }
+
+
+def evaluate_requirement(requirement_line: str) -> ConstraintStatus:
+    requirement = Requirement(requirement_line)
+    if requirement.marker is not None and not requirement.marker.evaluate():
+        return ConstraintStatus(
+            requirement=requirement_line,
+            name=requirement.name,
+            installed=None,
+            status="skipped-by-marker",
+            has_native_extensions=False,
+        )
+
+    try:
+        installed_version = importlib_metadata.version(requirement.name)
+    except importlib_metadata.PackageNotFoundError:
+        return ConstraintStatus(
+            requirement=requirement_line,
+            name=requirement.name,
+            installed=None,
+            status="missing",
+            has_native_extensions=False,
+        )
+
+    installed = Version(installed_version)
+    status = "ok" if installed in requirement.specifier else "drift"
+    return ConstraintStatus(
+        requirement=requirement_line,
+        name=requirement.name,
+        installed=installed_version,
+        status=status,
+        has_native_extensions=distribution_has_native_extensions(requirement.name),
+    )
+
+
+def distribution_has_native_extensions(name: str) -> bool:
+    try:
+        dist = importlib_metadata.distribution(name)
+    except importlib_metadata.PackageNotFoundError:
+        return False
+    files = getattr(dist, "files", None) or []
+    return any(Path(str(file)).suffix.lower() in _NATIVE_SUFFIXES for file in files)
+
+
+def print_report(report: dict[str, object]) -> None:
+    print(f"Constraints: {report['constraints_path']}")
+    print(f"Pyproject:   {report['pyproject_path']}")
+
+    missing = report["missing_from_constraints"]
+    extra = report["extra_in_constraints"]
+    if missing:
+        print("Missing from constraints:")
+        for item in missing:
+            print(f"  {item}")
+    if extra:
+        print("Extra in constraints:")
+        for item in extra:
+            print(f"  {item}")
+
+    print("Dependency status:")
+    for item in report["requirements"]:
+        installed = item["installed"] or "(not installed)"
+        native = " native" if item["has_native_extensions"] else ""
+        print(f"  {item['name']:18s} {item['status']:17s} {installed}{native}")
+
+
+def exit_code(report: dict[str, object]) -> int:
+    if report["missing_from_constraints"] or report["extra_in_constraints"]:
+        return 1
+    bad = {"missing", "drift"}
+    if any(item["status"] in bad for item in report["requirements"]):
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Check public dependency constraints drift and installed-package integrity."
+    )
+    parser.add_argument(
+        "--pyproject",
+        default="pyproject.toml",
+        help="Path to pyproject.toml (default: pyproject.toml)",
+    )
+    parser.add_argument(
+        "--constraints",
+        default="constraints/base-runtime.txt",
+        help="Path to constraints file (default: constraints/base-runtime.txt)",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON report")
+    args = parser.parse_args(argv)
+
+    report = check_constraints(
+        pyproject_path=Path(args.pyproject),
+        constraints_path=Path(args.constraints),
+    )
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print_report(report)
+    return exit_code(report)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_dependency_integrity.py
+++ b/scripts/check_dependency_integrity.py
@@ -12,7 +12,8 @@ try:
 except ModuleNotFoundError:  # pragma: no cover
     import tomli as tomllib
 
-from packaging.requirements import Requirement
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
 from packaging.version import Version
 
 
@@ -44,6 +45,26 @@ def load_constraints(constraints_path: Path) -> list[str]:
     return requirements
 
 
+def normalize_requirement(requirement_line: str) -> str:
+    try:
+        requirement = Requirement(requirement_line)
+    except InvalidRequirement:
+        return f"INVALID::{requirement_line.strip()}"
+
+    parts = [canonicalize_name(requirement.name)]
+    if requirement.extras:
+        extras = ",".join(sorted(requirement.extras))
+        parts[0] = f"{parts[0]}[{extras}]"
+    if requirement.specifier:
+        specifiers = ",".join(sorted(str(item) for item in requirement.specifier))
+        parts.append(specifiers)
+    if requirement.marker is not None:
+        parts.append(f"; {requirement.marker}")
+    if requirement.url:
+        parts.append(f" @ {requirement.url}")
+    return "".join(parts)
+
+
 def check_constraints(
     *,
     pyproject_path: Path,
@@ -52,21 +73,33 @@ def check_constraints(
     pyproject_reqs = load_pyproject_requirements(pyproject_path)
     constraint_reqs = load_constraints(constraints_path)
 
-    pyproject_set = set(pyproject_reqs)
-    constraints_set = set(constraint_reqs)
+    pyproject_map = {normalize_requirement(req): req for req in pyproject_reqs}
+    constraints_map = {normalize_requirement(req): req for req in constraint_reqs}
+
+    pyproject_set = set(pyproject_map)
+    constraints_set = set(constraints_map)
 
     statuses = [evaluate_requirement(req) for req in constraint_reqs]
     return {
         "constraints_path": str(constraints_path),
         "pyproject_path": str(pyproject_path),
-        "missing_from_constraints": sorted(pyproject_set - constraints_set),
-        "extra_in_constraints": sorted(constraints_set - pyproject_set),
+        "missing_from_constraints": sorted(pyproject_map[key] for key in pyproject_set - constraints_set),
+        "extra_in_constraints": sorted(constraints_map[key] for key in constraints_set - pyproject_set),
         "requirements": [status.__dict__ for status in statuses],
     }
 
 
 def evaluate_requirement(requirement_line: str) -> ConstraintStatus:
-    requirement = Requirement(requirement_line)
+    try:
+        requirement = Requirement(requirement_line)
+    except InvalidRequirement:
+        return ConstraintStatus(
+            requirement=requirement_line,
+            name=requirement_line,
+            installed=None,
+            status="invalid-requirement",
+            has_native_extensions=False,
+        )
     if requirement.marker is not None and not requirement.marker.evaluate():
         return ConstraintStatus(
             requirement=requirement_line,
@@ -132,7 +165,7 @@ def print_report(report: dict[str, object]) -> None:
 def exit_code(report: dict[str, object]) -> int:
     if report["missing_from_constraints"] or report["extra_in_constraints"]:
         return 1
-    bad = {"missing", "drift"}
+    bad = {"missing", "drift", "invalid-requirement"}
     if any(item["status"] in bad for item in report["requirements"]):
         return 1
     return 0

--- a/scripts/check_dependency_integrity.py
+++ b/scripts/check_dependency_integrity.py
@@ -14,7 +14,7 @@ except ModuleNotFoundError:  # pragma: no cover
 
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 
 
 _NATIVE_SUFFIXES = {".so", ".pyd", ".dylib", ".dll"}
@@ -120,7 +120,16 @@ def evaluate_requirement(requirement_line: str) -> ConstraintStatus:
             has_native_extensions=False,
         )
 
-    installed = Version(installed_version)
+    try:
+        installed = Version(installed_version)
+    except InvalidVersion:
+        return ConstraintStatus(
+            requirement=requirement_line,
+            name=requirement.name,
+            installed=installed_version,
+            status="invalid-installed-version",
+            has_native_extensions=distribution_has_native_extensions(requirement.name),
+        )
     status = "ok" if installed in requirement.specifier else "drift"
     return ConstraintStatus(
         requirement=requirement_line,
@@ -165,7 +174,7 @@ def print_report(report: dict[str, object]) -> None:
 def exit_code(report: dict[str, object]) -> int:
     if report["missing_from_constraints"] or report["extra_in_constraints"]:
         return 1
-    bad = {"missing", "drift", "invalid-requirement"}
+    bad = {"missing", "drift", "invalid-requirement", "invalid-installed-version"}
     if any(item["status"] in bad for item in report["requirements"]):
         return 1
     return 0

--- a/tests/test_dependency_integrity.py
+++ b/tests/test_dependency_integrity.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+_SCRIPT = Path(__file__).parent.parent / "scripts" / "check_dependency_integrity.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("check_dependency_integrity", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_dependency_integrity"] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+_mod = _load_module()
+
+
+def test_load_constraints_ignores_comments_and_blanks(tmp_path):
+    path = tmp_path / "constraints.txt"
+    path.write_text("# comment\n\nfastapi>=0.115.0,<1.0\n", encoding="utf-8")
+
+    assert _mod.load_constraints(path) == ["fastapi>=0.115.0,<1.0"]
+
+
+def test_evaluate_requirement_reports_missing_package(monkeypatch):
+    monkeypatch.setattr(
+        _mod.importlib_metadata,
+        "version",
+        lambda name: (_ for _ in ()).throw(_mod.importlib_metadata.PackageNotFoundError),
+    )
+
+    result = _mod.evaluate_requirement("pypdf>=6.7.5,<7.0")
+
+    assert result.status == "missing"
+    assert result.installed is None
+
+
+def test_evaluate_requirement_reports_drift(monkeypatch):
+    monkeypatch.setattr(_mod.importlib_metadata, "version", lambda name: "5.0.0")
+    monkeypatch.setattr(_mod, "distribution_has_native_extensions", lambda name: False)
+
+    result = _mod.evaluate_requirement("fastapi>=0.115.0,<1.0")
+
+    assert result.status == "drift"
+    assert result.installed == "5.0.0"
+
+
+def test_distribution_has_native_extensions(monkeypatch):
+    class FakeDist:
+        files = ["pkg/native.so", "pkg/__init__.py"]
+
+    monkeypatch.setattr(_mod.importlib_metadata, "distribution", lambda name: FakeDist())
+
+    assert _mod.distribution_has_native_extensions("chromadb") is True
+
+
+def test_check_constraints_reports_pyproject_alignment_and_status(tmp_path, monkeypatch):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+dependencies = [
+  "fastapi>=0.115.0,<1.0",
+  "pypdf>=6.7.5,<7.0",
+]
+""".strip(),
+        encoding="utf-8",
+    )
+    constraints = tmp_path / "constraints.txt"
+    constraints.write_text("fastapi>=0.115.0,<1.0\n", encoding="utf-8")
+
+    monkeypatch.setattr(_mod.importlib_metadata, "version", lambda name: "0.135.1")
+    monkeypatch.setattr(_mod, "distribution_has_native_extensions", lambda name: False)
+
+    report = _mod.check_constraints(pyproject_path=pyproject, constraints_path=constraints)
+
+    assert report["missing_from_constraints"] == ["pypdf>=6.7.5,<7.0"]
+    assert report["extra_in_constraints"] == []
+    assert report["requirements"][0]["status"] == "ok"
+
+
+def test_main_json_output_and_exit_code(tmp_path, monkeypatch, capsys):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+dependencies = [
+  "fastapi>=0.115.0,<1.0",
+]
+""".strip(),
+        encoding="utf-8",
+    )
+    constraints = tmp_path / "constraints.txt"
+    constraints.write_text("fastapi>=0.115.0,<1.0\n", encoding="utf-8")
+
+    monkeypatch.setattr(_mod.importlib_metadata, "version", lambda name: "0.135.1")
+    monkeypatch.setattr(_mod, "distribution_has_native_extensions", lambda name: False)
+
+    rc = _mod.main(
+        ["--pyproject", str(pyproject), "--constraints", str(constraints), "--json"]
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["requirements"][0]["status"] == "ok"

--- a/tests/test_dependency_integrity.py
+++ b/tests/test_dependency_integrity.py
@@ -65,6 +65,17 @@ def test_evaluate_requirement_reports_drift(monkeypatch):
     assert result.installed == "5.0.0"
 
 
+def test_evaluate_requirement_reports_invalid_installed_version(monkeypatch):
+    monkeypatch.setattr(_mod.importlib_metadata, "version", lambda name: "not-a-version")
+    monkeypatch.setattr(_mod, "distribution_has_native_extensions", lambda name: True)
+
+    result = _mod.evaluate_requirement("fastapi>=0.115.0,<1.0")
+
+    assert result.status == "invalid-installed-version"
+    assert result.installed == "not-a-version"
+    assert result.has_native_extensions is True
+
+
 def test_distribution_has_native_extensions(monkeypatch):
     class FakeDist:
         files = ["pkg/native.so", "pkg/__init__.py"]

--- a/tests/test_dependency_integrity.py
+++ b/tests/test_dependency_integrity.py
@@ -28,6 +28,20 @@ def test_load_constraints_ignores_comments_and_blanks(tmp_path):
     assert _mod.load_constraints(path) == ["fastapi>=0.115.0,<1.0"]
 
 
+def test_normalize_requirement_equates_reordered_specifiers():
+    left = "FastAPI <1.0, >=0.115.0"
+    right = "fastapi>=0.115.0,<1.0"
+
+    assert _mod.normalize_requirement(left) == _mod.normalize_requirement(right)
+
+
+def test_evaluate_requirement_reports_invalid_requirement():
+    result = _mod.evaluate_requirement("not a valid requirement >>>")
+
+    assert result.status == "invalid-requirement"
+    assert result.installed is None
+
+
 def test_evaluate_requirement_reports_missing_package(monkeypatch):
     monkeypatch.setattr(
         _mod.importlib_metadata,
@@ -85,6 +99,29 @@ dependencies = [
     assert report["requirements"][0]["status"] == "ok"
 
 
+def test_check_constraints_normalizes_equivalent_requirement_strings(tmp_path, monkeypatch):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+dependencies = [
+  "fastapi <1.0, >=0.115.0",
+]
+""".strip(),
+        encoding="utf-8",
+    )
+    constraints = tmp_path / "constraints.txt"
+    constraints.write_text("fastapi>=0.115.0,<1.0\n", encoding="utf-8")
+
+    monkeypatch.setattr(_mod.importlib_metadata, "version", lambda name: "0.135.1")
+    monkeypatch.setattr(_mod, "distribution_has_native_extensions", lambda name: False)
+
+    report = _mod.check_constraints(pyproject_path=pyproject, constraints_path=constraints)
+
+    assert report["missing_from_constraints"] == []
+    assert report["extra_in_constraints"] == []
+
+
 def test_main_json_output_and_exit_code(tmp_path, monkeypatch, capsys):
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
@@ -109,3 +146,26 @@ dependencies = [
     assert rc == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["requirements"][0]["status"] == "ok"
+
+
+def test_main_returns_failure_for_invalid_requirement_in_constraints(tmp_path, capsys):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+dependencies = [
+  "fastapi>=0.115.0,<1.0",
+]
+""".strip(),
+        encoding="utf-8",
+    )
+    constraints = tmp_path / "constraints.txt"
+    constraints.write_text("not a valid requirement >>>\n", encoding="utf-8")
+
+    rc = _mod.main(
+        ["--pyproject", str(pyproject), "--constraints", str(constraints), "--json"]
+    )
+
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["requirements"][0]["status"] == "invalid-requirement"


### PR DESCRIPTION
## Summary
- add a checked-in base runtime constraints file for public release verification
- add a dependency integrity verifier script for pyproject/constraints drift and installed-package drift
- document the low-trust dependency verification workflow in operations docs
- add tests for the verifier behavior

## Why
This gives Alcove a concrete, auditable dependency integrity workflow without inventing a full lockfile system. It also surfaces native-extension packages and environment drift explicitly.

## Validation
- `pytest -q tests/test_dependency_integrity.py`
- `python3 scripts/check_dependency_integrity.py --json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dependency verification and integrity-checking tool to validate constraints, detect version drift, and flag packages with native extensions.

* **Documentation**
  * Added an operations guide section describing how to run dependency verification and interpret reports.

* **Tests**
  * Added tests covering normalization, invalid constraint handling, drift detection, native-extension detection, and CLI exit/report behavior.

* **Chores**
  * Tightened a runtime dependency version range for release stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Spitfire-Cowboy/alcove/pull/138)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->