### PR TITLE
show index target and network mode in status

### DIFF
--- a/alcove/cli.py
+++ b/alcove/cli.py
@@ -71,8 +71,12 @@ def cmd_status(_args):
     from alcove.index.backend import get_backend
 
     index_path = os.getenv("CHROMA_PATH", "./data/chroma")
+    chroma_host = os.getenv("CHROMA_HOST", "").strip()
+    chroma_port = os.getenv("CHROMA_PORT", "8000").strip()
     embedder_name = os.getenv("EMBEDDER", "hash")
     backend_name = os.getenv("VECTOR_BACKEND", "chromadb")
+    index_target = f"{chroma_host}:{chroma_port}" if chroma_host else index_path
+    network_mode = "remote" if chroma_host else "none required"
 
     try:
         embedder = get_embedder()
@@ -83,10 +87,11 @@ def cmd_status(_args):
         count_str = f"(unavailable: {exc})"
 
     print(f"  index path:     {index_path}")
+    print(f"  index target:   {index_target}")
     print(f"  backend:        {backend_name}")
     print(f"  embedder:       {embedder_name}")
     print(f"  vectors:        {count_str}")
-    print(f"  network:        none required")
+    print(f"  network:        {network_mode}")
 
 
 def cmd_plugins(_args):

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -125,9 +125,11 @@ class TestCmdStatus:
         cmd_status(argparse.Namespace())
         out = capsys.readouterr().out
         assert "index path:" in out
+        assert "index target:" in out
         assert "backend:" in out
         assert "embedder:" in out
         assert "vectors:" in out
+        assert "network:" in out
 
     def test_status_unavailable_backend(self, capsys, monkeypatch):
         monkeypatch.setenv("VECTOR_BACKEND", "nonexistent")
@@ -135,6 +137,15 @@ class TestCmdStatus:
         cmd_status(argparse.Namespace())
         out = capsys.readouterr().out
         assert "unavailable" in out
+
+    def test_status_remote_target(self, capsys, monkeypatch):
+        monkeypatch.setenv("CHROMA_HOST", "127.0.0.1")
+        monkeypatch.setenv("CHROMA_PORT", "18080")
+        from alcove.cli import cmd_status
+        cmd_status(argparse.Namespace())
+        out = capsys.readouterr().out
+        assert "index target:   127.0.0.1:18080" in out
+        assert "network:        remote" in out
 
 
 class TestCmdPlugins:


### PR DESCRIPTION
## Summary
- extend `alcove status` to report the effective index target
- surface whether the current index configuration is local or remote
- add focused CLI coverage for the new output

## Testing
- pytest -q tests/test_cli_coverage.py tests/test_cli.py
- pytest --cov=alcove.cli --cov-report=term-missing -q tests/test_cli_coverage.py tests/test_cli.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Status command now displays index target location and network mode, automatically reflecting whether you're using a local path or remote host configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Spitfire-Cowboy/alcove/pull/140)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->