### PR TITLE
batch chromadb upserts for large indexes

### DIFF
--- a/alcove/index/backend.py
+++ b/alcove/index/backend.py
@@ -8,6 +8,28 @@ from chromadb.config import Settings
 
 from .embedder import get_collection_name
 
+_UPSERT_BATCH = 1000
+
+
+def _batched_upsert_inputs(ids, embeddings, documents, metadatas):
+    inputs = {
+        "ids": ids,
+        "embeddings": embeddings,
+        "documents": documents,
+        "metadatas": metadatas,
+    }
+    lengths = {name: len(values) for name, values in inputs.items()}
+    if len(set(lengths.values())) != 1:
+        raise ValueError(f"All inputs must have the same length, got: {lengths}")
+    for start in range(0, len(ids), _UPSERT_BATCH):
+        stop = start + _UPSERT_BATCH
+        yield {
+            "ids": ids[start:stop],
+            "embeddings": embeddings[start:stop],
+            "documents": documents[start:stop],
+            "metadatas": metadatas[start:stop],
+        }
+
 
 class MultiChromaBackend:
     """Vector backend that fans out across ALL ChromaDB collections in CHROMA_PATH.
@@ -77,12 +99,18 @@ class MultiChromaBackend:
         for logical, group in groups.items():
             physical = get_collection_name(logical)
             col = self._client.get_or_create_collection(name=physical)
-            col.upsert(
-                ids=group["ids"],
-                documents=group["documents"],
-                metadatas=group["metadatas"],
-                embeddings=group["embeddings"],
-            )
+            for batch in _batched_upsert_inputs(
+                group["ids"],
+                group["embeddings"],
+                group["documents"],
+                group["metadatas"],
+            ):
+                col.upsert(
+                    ids=batch["ids"],
+                    documents=batch["documents"],
+                    metadatas=batch["metadatas"],
+                    embeddings=batch["embeddings"],
+                )
 
     def query(self, embedding, k=3, collections: Optional[List[str]] = None):
         """Fan out query to all (or filtered) collections and merge by distance."""
@@ -295,9 +323,13 @@ class ChromaBackend:
         # Ensure every metadata dict has a "collection" key.
         for meta in metadatas:
             meta.setdefault("collection", "default")
-        self._collection.upsert(
-            ids=ids, documents=documents, metadatas=metadatas, embeddings=embeddings,
-        )
+        for batch in _batched_upsert_inputs(ids, embeddings, documents, metadatas):
+            self._collection.upsert(
+                ids=batch["ids"],
+                documents=batch["documents"],
+                metadatas=batch["metadatas"],
+                embeddings=batch["embeddings"],
+            )
 
     def query(self, embedding, k=3, collections: Optional[List[str]] = None):
         kwargs: dict = {"query_embeddings": [embedding], "n_results": k}

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -98,6 +98,56 @@ class TestChromaBackend:
             }
         ]
 
+    def test_add_batches_large_upserts(self):
+        from alcove.index.backend import ChromaBackend, _UPSERT_BATCH
+
+        class FakeCollection:
+            def __init__(self):
+                self.calls = []
+
+            def upsert(self, *, ids, documents, metadatas, embeddings):
+                self.calls.append(
+                    {
+                        "ids": ids,
+                        "documents": documents,
+                        "metadatas": metadatas,
+                        "embeddings": embeddings,
+                    }
+                )
+
+        backend = ChromaBackend.__new__(ChromaBackend)
+        backend._collection = FakeCollection()
+        total = _UPSERT_BATCH + 25
+        ids = [f"doc-{i}" for i in range(total)]
+        docs = [f"doc text {i}" for i in range(total)]
+        metas = [{"source": f"{i}.txt"} for i in range(total)]
+        vecs = [[float(i)] for i in range(total)]
+
+        backend.add(ids=ids, embeddings=vecs, documents=docs, metadatas=metas)
+
+        assert len(backend._collection.calls) == 2
+        assert len(backend._collection.calls[0]["ids"]) == _UPSERT_BATCH
+        assert len(backend._collection.calls[1]["ids"]) == 25
+        assert backend._collection.calls[0]["metadatas"][0]["collection"] == "default"
+
+    def test_add_rejects_mismatched_lengths(self):
+        from alcove.index.backend import ChromaBackend
+
+        class FakeCollection:
+            def upsert(self, **kwargs):
+                raise AssertionError("upsert should not be called for invalid input")
+
+        backend = ChromaBackend.__new__(ChromaBackend)
+        backend._collection = FakeCollection()
+
+        with pytest.raises(ValueError, match="same length"):
+            backend.add(
+                ids=["a", "b"],
+                embeddings=[[0.1]],
+                documents=["doc a", "doc b"],
+                metadatas=[{"source": "a.txt"}, {"source": "b.txt"}],
+            )
+
 
 class _MetadataCollection:
     def __init__(self, name="docs", metadatas=None, documents=None, ids=None, *, raises=False):
@@ -126,6 +176,48 @@ def test_multi_chroma_iter_metadata_records_enriches_collection():
     assert backend.iter_metadata_records() == [
         {"source": "paper.md", "collection": "science", "__document": "body", "__chunk_id": "chunk-1"}
     ]
+
+
+def test_multi_chroma_add_batches_large_group(monkeypatch):
+    from alcove.index.backend import MultiChromaBackend, _UPSERT_BATCH
+
+    class FakeCollection:
+        def __init__(self):
+            self.calls = []
+
+        def upsert(self, *, ids, documents, metadatas, embeddings):
+            self.calls.append(
+                {
+                    "ids": ids,
+                    "documents": documents,
+                    "metadatas": metadatas,
+                    "embeddings": embeddings,
+                }
+            )
+
+    class FakeClient:
+        def __init__(self, collection):
+            self.collection = collection
+
+        def get_or_create_collection(self, name):
+            return self.collection
+
+    fake_collection = FakeCollection()
+    backend = MultiChromaBackend.__new__(MultiChromaBackend)
+    backend._client = FakeClient(fake_collection)
+    monkeypatch.setenv("CHROMA_COLLECTION", "fallback")
+
+    total = _UPSERT_BATCH + 10
+    ids = [f"doc-{i}" for i in range(total)]
+    docs = [f"doc text {i}" for i in range(total)]
+    metas = [{"source": f"{i}.txt", "collection": "letters"} for i in range(total)]
+    vecs = [[float(i)] for i in range(total)]
+
+    backend.add(ids=ids, embeddings=vecs, documents=docs, metadatas=metas)
+
+    assert len(fake_collection.calls) == 2
+    assert len(fake_collection.calls[0]["ids"]) == _UPSERT_BATCH
+    assert len(fake_collection.calls[1]["ids"]) == 10
 
 
 def test_multi_root_iter_metadata_records_enriches_collection():


### PR DESCRIPTION
## Summary
- batch ChromaDB upserts to stay under collection limits on larger indexes
- validate equal-length add inputs before attempting backend writes
- add focused backend coverage for batching and validation behavior

## Testing
- pytest -q tests/test_backend.py tests/test_multi_collection.py
- pytest --cov=alcove.index.backend --cov-report=term-missing -q tests/test_backend.py tests/test_multi_collection.py