### PR TITLE
add rtf extractor support

### DIFF
--- a/alcove/ingest/extractors.py
+++ b/alcove/ingest/extractors.py
@@ -95,6 +95,15 @@ def extract_pptx(path: Path) -> str:
                 continue
             for paragraph in shape.text_frame.paragraphs:
                 text = paragraph.text.strip()
-                if text:
-                    texts.append(text)
+            if text:
+                texts.append(text)
     return "\n".join(texts)
+
+
+def extract_rtf(path: Path) -> str:
+    try:
+        from striprtf.striprtf import rtf_to_text
+    except ImportError as e:
+        raise ImportError("striprtf is required for .rtf support: pip install 'alcove-search[rtf]'") from e
+
+    return rtf_to_text(path.read_text(encoding="utf-8", errors="ignore"))

--- a/alcove/ingest/pipeline.py
+++ b/alcove/ingest/pipeline.py
@@ -18,6 +18,7 @@ from .extractors import (
     extract_md,
     extract_pdf,
     extract_pptx,
+    extract_rtf,
     extract_rst,
     extract_tsv,
     extract_txt,
@@ -39,6 +40,7 @@ _BUILTIN_EXTRACTORS = {
     ".jsonl": extract_jsonl,
     ".docx": extract_docx,
     ".pptx": extract_pptx,
+    ".rtf": extract_rtf,
 }
 
 

--- a/alcove/query/api.py
+++ b/alcove/query/api.py
@@ -41,7 +41,7 @@ SUPPORTED_EXTENSIONS = {
     ".md", ".rst",
     ".csv", ".tsv",
     ".json", ".jsonl",
-    ".docx",
+    ".docx", ".rtf",
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.3", "python-docx>=1.0", "python-pptx>=1.0", "httpx>=0.27", "defusedxml>=0.7", "requests>=2.28"]
+dev = ["pytest>=8.3", "python-docx>=1.0", "python-pptx>=1.0", "httpx>=0.27", "defusedxml>=0.7", "requests>=2.28", "striprtf>=0.0.26"]
 docx = ["python-docx>=1.0"]
 pptx = ["python-pptx>=1.0"]
+rtf = ["striprtf>=0.0.26"]
 semantic = ["sentence-transformers>=3.0"]
 epub = ["ebooklib>=0.18,<1.0"]
 zvec = ["zvec>=0.1"]

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -129,6 +129,38 @@ def test_extract_pptx_raises_helpful_import_error(tmp_path, monkeypatch):
         extractors.extract_pptx(f)
 
 
+def test_extract_rtf_returns_plain_text(tmp_path):
+    pytest.importorskip("striprtf.striprtf", reason="striprtf not installed")
+    from alcove.ingest.extractors import extract_rtf
+
+    f = tmp_path / "sample.rtf"
+    f.write_text(r"{\rtf1\ansi Alcove {\b RTF} extractor test.\par Second paragraph.}")
+
+    result = extract_rtf(f)
+    assert "Alcove" in result
+    assert "RTF" in result
+    assert "Second paragraph." in result
+    assert "\\b" not in result
+
+
+def test_extract_rtf_requires_striprtf(tmp_path, monkeypatch):
+    from alcove.ingest import extractors
+
+    f = tmp_path / "sample.rtf"
+    f.write_text(r"{\rtf1\ansi missing dependency test}")
+
+    real_import = __import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name in {"striprtf", "striprtf.striprtf"}:
+            raise ImportError("missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", blocked_import)
+    with pytest.raises(ImportError, match=r"striprtf is required.*alcove-search\[rtf\]"):
+        extractors.extract_rtf(f)
+
+
 def test_pipeline_dispatch_includes_html(tmp_path):
     """Pipeline routes .html files through the extractor without error."""
     from alcove.ingest.pipeline import run
@@ -166,6 +198,20 @@ def test_pipeline_dispatch_includes_pptx(tmp_path):
     assert n >= 1
     records = [json.loads(line) for line in out.read_text().splitlines()]
     assert any("Deck heading" in r["chunk"] for r in records)
+
+
+def test_pipeline_dispatch_includes_rtf(tmp_path):
+    pytest.importorskip("striprtf.striprtf", reason="striprtf not installed")
+    from alcove.ingest.pipeline import run
+
+    f = tmp_path / "sample.rtf"
+    f.write_text(r"{\rtf1\ansi Pipeline {\b RTF} content.}")
+    out = tmp_path / "chunks.jsonl"
+    n = run(raw_dir=str(tmp_path), out_file=str(out))
+
+    assert n >= 1
+    records = [json.loads(line) for line in out.read_text().splitlines()]
+    assert any("Pipeline RTF content." in r["chunk"] for r in records)
 
 
 def test_extract_tsv_tab_separated(tmp_path):


### PR DESCRIPTION
## Summary
- add built-in RTF extraction support
- allow RTF uploads through the API ingest path
- add focused tests for RTF extraction behavior

## Testing
- pytest -q tests/test_extractors.py tests/test_pipeline_empty.py tests/test_api.py
- pytest --cov=alcove.ingest.extractors --cov=alcove.ingest.pipeline --cov=alcove.query.api --cov-report=term-missing -q tests/test_extractors.py tests/test_pipeline_empty.py tests/test_api.py