### PR TITLE
add xlsx extractor support

### DIFF
--- a/alcove/ingest/extractors.py
+++ b/alcove/ingest/extractors.py
@@ -98,3 +98,23 @@ def extract_pptx(path: Path) -> str:
                 if text:
                     texts.append(text)
     return "\n".join(texts)
+
+
+def extract_xlsx(path: Path) -> str:
+    try:
+        import openpyxl
+    except ImportError as e:
+        raise ImportError("openpyxl is required for .xlsx support: pip install 'alcove-search[xlsx]'") from e
+
+    wb = openpyxl.load_workbook(str(path), read_only=True, data_only=True)
+    try:
+        tokens: List[str] = []
+        for sheet_name in wb.sheetnames:
+            ws = wb[sheet_name]
+            for row in ws.iter_rows():
+                for cell in row:
+                    if cell.value is not None:
+                        tokens.append(str(cell.value))
+    finally:
+        wb.close()
+    return " ".join(tokens)

--- a/alcove/ingest/pipeline.py
+++ b/alcove/ingest/pipeline.py
@@ -21,6 +21,7 @@ from .extractors import (
     extract_rst,
     extract_tsv,
     extract_txt,
+    extract_xlsx,
 )
 
 logger = logging.getLogger(__name__)
@@ -39,6 +40,7 @@ _BUILTIN_EXTRACTORS = {
     ".jsonl": extract_jsonl,
     ".docx": extract_docx,
     ".pptx": extract_pptx,
+    ".xlsx": extract_xlsx,
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.3", "python-docx>=1.0", "python-pptx>=1.0", "httpx>=0.27", "defusedxml>=0.7", "requests>=2.28"]
+dev = ["pytest>=8.3", "python-docx>=1.0", "python-pptx>=1.0", "httpx>=0.27", "defusedxml>=0.7", "requests>=2.28", "openpyxl>=3.1"]
 docx = ["python-docx>=1.0"]
 pptx = ["python-pptx>=1.0"]
+xlsx = ["openpyxl>=3.1"]
 semantic = ["sentence-transformers>=3.0"]
 epub = ["ebooklib>=0.18,<1.0"]
 zvec = ["zvec>=0.1"]

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -129,6 +129,80 @@ def test_extract_pptx_raises_helpful_import_error(tmp_path, monkeypatch):
         extractors.extract_pptx(f)
 
 
+def test_extract_xlsx_returns_cell_text(tmp_path):
+    openpyxl = pytest.importorskip("openpyxl", reason="openpyxl not installed")
+    from alcove.ingest.extractors import extract_xlsx
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Sheet1"
+    ws["A1"] = "Name"
+    ws["B1"] = "Score"
+    ws["A2"] = "Alice"
+    ws["B2"] = 42
+    f = tmp_path / "sample.xlsx"
+    wb.save(str(f))
+
+    result = extract_xlsx(f)
+    assert "Name" in result
+    assert "Alice" in result
+    assert "42" in result
+    assert "Score" in result
+
+
+def test_extract_xlsx_multiple_sheets(tmp_path):
+    openpyxl = pytest.importorskip("openpyxl", reason="openpyxl not installed")
+    from alcove.ingest.extractors import extract_xlsx
+
+    wb = openpyxl.Workbook()
+    ws1 = wb.active
+    ws1.title = "Sheet1"
+    ws1["A1"] = "hello"
+    ws2 = wb.create_sheet("Sheet2")
+    ws2["A1"] = "world"
+    f = tmp_path / "multi.xlsx"
+    wb.save(str(f))
+
+    result = extract_xlsx(f)
+    assert "hello" in result
+    assert "world" in result
+
+
+def test_extract_xlsx_skips_none_cells(tmp_path):
+    openpyxl = pytest.importorskip("openpyxl", reason="openpyxl not installed")
+    from alcove.ingest.extractors import extract_xlsx
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws["A1"] = "alpha"
+    ws["B1"] = None
+    ws["C1"] = "omega"
+    f = tmp_path / "sparse.xlsx"
+    wb.save(str(f))
+
+    result = extract_xlsx(f)
+    assert "alpha" in result
+    assert "omega" in result
+
+
+def test_extract_xlsx_requires_openpyxl(tmp_path, monkeypatch):
+    from alcove.ingest import extractors
+
+    f = tmp_path / "sample.xlsx"
+    f.write_bytes(b"not-a-real-xlsx")
+
+    real_import = __import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name == "openpyxl":
+            raise ImportError("missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", blocked_import)
+    with pytest.raises(ImportError, match=r"openpyxl is required.*alcove-search\[xlsx\]"):
+        extractors.extract_xlsx(f)
+
+
 def test_pipeline_dispatch_includes_html(tmp_path):
     """Pipeline routes .html files through the extractor without error."""
     from alcove.ingest.pipeline import run
@@ -166,6 +240,24 @@ def test_pipeline_dispatch_includes_pptx(tmp_path):
     assert n >= 1
     records = [json.loads(line) for line in out.read_text().splitlines()]
     assert any("Deck heading" in r["chunk"] for r in records)
+
+
+def test_pipeline_dispatch_includes_xlsx(tmp_path):
+    openpyxl = pytest.importorskip("openpyxl", reason="openpyxl not installed")
+    from alcove.ingest.pipeline import run
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws["A1"] = "spreadsheet content for search"
+    f = tmp_path / "sheet.xlsx"
+    wb.save(str(f))
+    out = tmp_path / "chunks.jsonl"
+
+    n = run(raw_dir=str(tmp_path), out_file=str(out))
+
+    assert n >= 1
+    records = [json.loads(line) for line in out.read_text().splitlines()]
+    assert any("spreadsheet content for search" in r["chunk"] for r in records)
 
 
 def test_extract_tsv_tab_separated(tmp_path):


### PR DESCRIPTION
## Summary
- add built-in XLSX extraction support
- wire XLSX documents into the ingest pipeline
- add focused tests for spreadsheet extraction behavior

## Testing
- pytest -q tests/test_extractors.py tests/test_pipeline_empty.py tests/test_api.py
- pytest --cov=alcove.ingest.extractors --cov=alcove.ingest.pipeline --cov=alcove.query.api --cov-report=term-missing -q tests/test_extractors.py tests/test_pipeline_empty.py tests/test_api.py