### PR TITLE
add odt extractor support

### DIFF
--- a/alcove/ingest/extractors.py
+++ b/alcove/ingest/extractors.py
@@ -98,3 +98,21 @@ def extract_pptx(path: Path) -> str:
                 if text:
                     texts.append(text)
     return "\n".join(texts)
+
+
+def extract_odt(path: Path) -> str:
+    try:
+        from odf import teletype
+        from odf.opendocument import load
+        from odf.text import H, P
+    except ImportError as e:
+        raise ImportError("odfpy is required for .odt support: pip install 'alcove-search[odt]'") from e
+
+    doc = load(str(path))
+    elements = doc.getElementsByType(H) + doc.getElementsByType(P)
+    texts = []
+    for element in elements:
+        text = teletype.extractText(element).strip()
+        if text:
+            texts.append(text)
+    return "\n".join(texts)

--- a/alcove/ingest/pipeline.py
+++ b/alcove/ingest/pipeline.py
@@ -16,6 +16,7 @@ from .extractors import (
     extract_json,
     extract_jsonl,
     extract_md,
+    extract_odt,
     extract_pdf,
     extract_pptx,
     extract_rst,
@@ -38,6 +39,7 @@ _BUILTIN_EXTRACTORS = {
     ".json": extract_json,
     ".jsonl": extract_jsonl,
     ".docx": extract_docx,
+    ".odt": extract_odt,
     ".pptx": extract_pptx,
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.3", "python-docx>=1.0", "python-pptx>=1.0", "httpx>=0.27", "defusedxml>=0.7", "requests>=2.28"]
+dev = ["pytest>=8.3", "python-docx>=1.0", "python-pptx>=1.0", "httpx>=0.27", "defusedxml>=0.7", "requests>=2.28", "odfpy>=1.4"]
 docx = ["python-docx>=1.0"]
+odt = ["odfpy>=1.4"]
 pptx = ["python-pptx>=1.0"]
 semantic = ["sentence-transformers>=3.0"]
 epub = ["ebooklib>=0.18,<1.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,23 +1,26 @@
-[build-system]
-requires = ["setuptools>=68", "wheel"]
-build-backend = "setuptools.build_meta"
-
 [project]
 name = "alcove-search"
-version = "0.1.0"
-description = "Local retrieval + semantic search package for Markdown/JSON/TSV/CSV sources"
+version = "0.4.0"
+description = "Local-first document retrieval. Your data never leaves your disk."
 readme = "README.md"
+license = {text = "Apache-2.0"}
 requires-python = ">=3.10"
+authors = [
+    {name = "John Malone", email = "john.malone@gmail.com"},
+]
+keywords = ["retrieval", "search", "local-first", "chromadb", "documents"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Text Processing :: Indexing",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+]
 dependencies = [
-    "chromadb>=0.5,<0.6",
-    "pydantic>=2.6,<3.0",
-    "typer>=0.12,<0.13",
-    "fastapi>=0.111,<1.0",
-    "uvicorn[standard]>=0.30,<0.31",
-    "sentence-transformers>=3.0,<4.0",
-    "pypdf>=4.2,<5.0",
-    "python-docx>=1.1,<2.0",
-    "python-pptx>=1.0,<2.0",
+    "chromadb>=1.0,<2.0",
+    "fastapi>=0.115.0,<1.0",
+    "uvicorn>=0.30.0,<1.0",
+    "pypdf>=6.7.5,<7.0",
     "beautifulsoup4>=4.12,<5.0",
     "jinja2>=3.1,<4.0",
     "python-multipart>=0.0.6,<1.0",
@@ -37,13 +40,36 @@ epub = ["ebooklib>=0.18,<1.0"]
 zvec = ["zvec>=0.1"]
 tools = ["defusedxml>=0.7", "requests>=2.28"]
 
-[project.scripts]
-alcove = "alcove.cli:app"
-alcove-server = "alcove.server:main"
-alcove-merge-ready-prs = "alcove.tools.merge_ready_prs:app"
+[project.urls]
+Homepage = "https://spitfire-cowboy.github.io/alcove/"
+Repository = "https://github.com/Spitfire-Cowboy/alcove"
 
-[tool.setuptools]
+[project.scripts]
+alcove = "alcove.cli:main"
+alcove-mcp = "alcove.mcp_server:main"
+
+[tool.hatch.build.targets.wheel]
 packages = ["alcove"]
 
-[tool.setuptools.package-data]
-alcove = ["web/templates/*.html"]
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["alcove"]
+
+[tool.coverage.report]
+show_missing = true
+skip_empty = true
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.",
+    "if TYPE_CHECKING:",
+]
+
+[tool.briefcase]
+bundle = "com.alcove-search"
+url = "https://github.com/Spitfire-Cowboy/alcove"

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -87,6 +87,30 @@ def test_extract_docx_returns_paragraph_text(tmp_path):
     assert "Alcove document extraction test." in result
 
 
+def test_extract_odt_returns_paragraph_text(tmp_path):
+    pytest.importorskip("odf.opendocument", reason="odfpy not installed")
+    from odf import teletype
+    from odf.opendocument import OpenDocumentText
+    from odf.text import H, P
+
+    from alcove.ingest.extractors import extract_odt
+
+    doc = OpenDocumentText()
+    heading = H(outlinelevel=1)
+    teletype.addTextToElement(heading, "Alcove ODT Heading")
+    doc.text.addElement(heading)
+    paragraph = P()
+    teletype.addTextToElement(paragraph, "ODT extraction body text.")
+    doc.text.addElement(paragraph)
+
+    f = tmp_path / "sample.odt"
+    doc.save(str(f))
+
+    result = extract_odt(f)
+    assert "Alcove ODT Heading" in result
+    assert "ODT extraction body text." in result
+
+
 def _write_sample_pptx(path: Path, lines: list[str]) -> None:
     pptx = pytest.importorskip("pptx", reason="python-pptx not installed")
     from pptx.util import Inches
@@ -129,6 +153,24 @@ def test_extract_pptx_raises_helpful_import_error(tmp_path, monkeypatch):
         extractors.extract_pptx(f)
 
 
+def test_extract_odt_requires_odfpy(tmp_path, monkeypatch):
+    from alcove.ingest import extractors
+
+    f = tmp_path / "sample.odt"
+    f.write_bytes(b"not-a-real-odt")
+
+    real_import = __import__
+
+    def blocked_import(name, *args, **kwargs):
+        if name in {"odf", "odf.opendocument", "odf.text"}:
+            raise ImportError("missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", blocked_import)
+    with pytest.raises(ImportError, match=r"odfpy is required.*alcove-search\[odt\]"):
+        extractors.extract_odt(f)
+
+
 def test_pipeline_dispatch_includes_html(tmp_path):
     """Pipeline routes .html files through the extractor without error."""
     from alcove.ingest.pipeline import run
@@ -166,6 +208,30 @@ def test_pipeline_dispatch_includes_pptx(tmp_path):
     assert n >= 1
     records = [json.loads(line) for line in out.read_text().splitlines()]
     assert any("Deck heading" in r["chunk"] for r in records)
+
+
+def test_pipeline_dispatch_includes_odt(tmp_path):
+    pytest.importorskip("odf.opendocument", reason="odfpy not installed")
+    from odf import teletype
+    from odf.opendocument import OpenDocumentText
+    from odf.text import P
+
+    from alcove.ingest.pipeline import run
+
+    doc = OpenDocumentText()
+    paragraph = P()
+    teletype.addTextToElement(paragraph, "Pipeline ODT content.")
+    doc.text.addElement(paragraph)
+
+    f = tmp_path / "sample.odt"
+    doc.save(str(f))
+    out = tmp_path / "chunks.jsonl"
+
+    n = run(raw_dir=str(tmp_path), out_file=str(out))
+
+    assert n >= 1
+    records = [json.loads(line) for line in out.read_text().splitlines()]
+    assert any("Pipeline ODT content." in r["chunk"] for r in records)
 
 
 def test_extract_tsv_tab_separated(tmp_path):


### PR DESCRIPTION
## Summary
- add built-in ODT extraction support
- wire ODT documents into the ingest pipeline
- add focused tests for ODT extraction behavior

## Testing
- pytest -q tests/test_extractors.py tests/test_pipeline_empty.py tests/test_api.py
- pytest --cov=alcove.ingest.extractors --cov=alcove.ingest.pipeline --cov=alcove.query.api --cov-report=term-missing -q tests/test_extractors.py tests/test_pipeline_empty.py tests/test_api.py